### PR TITLE
Support for Math Expressions as Argument Types

### DIFF
--- a/bespokeasm/expression/__init__.py
+++ b/bespokeasm/expression/__init__.py
@@ -1,0 +1,132 @@
+#
+# This expression parser was heavily inspired by:
+#       https://github.com/gnebehay/parser
+#
+# To use this class, import the following:
+#
+#    from bespokeasm.expression import parse_expression, ExpresionType
+#
+
+import enum
+import operator
+import re
+import sys
+
+from bespokeasm.utilities import is_string_numeric, parse_numeric_string
+from bespokeasm.line_object.label_line import is_valid_label
+
+class TokenType(enum.Enum):
+    T_NUM = 0
+    T_LABEL = 1
+    T_PLUS = 2
+    T_MINUS = 3
+    T_MULT = 4
+    T_DIV = 5
+    T_LPAR = 6
+    T_RPAR = 7
+    T_END = 8
+
+class ExpressionNode:
+    _operations = {
+        TokenType.T_PLUS: operator.add,
+        TokenType.T_MINUS: operator.sub,
+        TokenType.T_MULT: operator.mul,
+        TokenType.T_DIV: operator.truediv
+    }
+
+    def __init__(self, token_type: TokenType, value=None):
+        self.token_type = token_type
+        self.value = value
+        self.left_child = None
+        self.right_child = None
+
+    def _numeric_value(self, label_map: dict) -> int:
+        if self.token_type == TokenType.T_NUM:
+            return self.value
+        elif self.token_type == TokenType.T_LABEL:
+            # in ths case value is a label
+            return label_map[self.value]
+        else:
+            # this wasn't a numeric value
+            return None
+
+    def _compute(self, label_map: dict[str,int]) -> float:
+        if self.token_type in [TokenType.T_NUM, TokenType.T_LABEL]:
+            return float(self._numeric_value(label_map))
+        left_result = self.left_child._compute(label_map)
+        right_result = self.right_child._compute(label_map)
+        operation = ExpressionNode._operations[self.token_type]
+        return operation(left_result, right_result)
+
+    def get_value(self, label_map: dict[str,int]) -> int:
+        return int(self._compute(label_map))
+
+ExpresionType = ExpressionNode
+
+def parse_expression(line_num: int, expression: str) -> ExpresionType:
+    tokens = _lexical_analysis(line_num, expression)
+    ast = _parse_e(line_num, tokens)
+    _match(line_num, tokens, TokenType.T_END)
+    return ast
+
+def _lexical_analysis(line_num: int, s: str) -> list[ExpressionNode]:
+    mappings = {
+        '+': TokenType.T_PLUS,
+        '-': TokenType.T_MINUS,
+        '*': TokenType.T_MULT,
+        '/': TokenType.T_DIV,
+        '(': TokenType.T_LPAR,
+        ')': TokenType.T_RPAR,
+    }
+
+    tokens = []
+    # split the string on white space
+    # expression_parts = s.split(None)
+    expression_parts = re.findall(r'(?:\%|\$|b|0x)?[\w]+|[\+\-\*\/\(\)]', s)
+    for part in expression_parts:
+        if len(part) == 1 and part in mappings:
+            token_type = mappings[part]
+            token = ExpressionNode(token_type, value=part)
+        elif is_string_numeric(part):
+            token = ExpressionNode(TokenType.T_NUM, value=parse_numeric_string(part))
+        elif is_valid_label(part):
+            token = ExpressionNode(TokenType.T_LABEL, value=part)
+        else:
+            sys.exit(f'ERROR: line {line_num} - invalid token: {part}')
+        tokens.append(token)
+    tokens.append(ExpressionNode(TokenType.T_END))
+    return tokens
+
+def _parse_e(line_num: int, tokens: list[ExpressionNode]) -> ExpressionNode:
+    left_node = _parse_e2(line_num, tokens)
+    while tokens[0].token_type in [TokenType.T_PLUS, TokenType.T_MINUS]:
+        node = tokens.pop(0)
+        node.left_child = left_node
+        node.right_child = _parse_e2(line_num, tokens)
+        left_node = node
+    return left_node
+
+def _parse_e2(line_num: int, tokens: list[ExpressionNode]) -> ExpressionNode:
+    left_node = _parse_e3(line_num, tokens)
+    while tokens[0].token_type in [TokenType.T_MULT, TokenType.T_DIV]:
+        node = tokens.pop(0)
+        node.left_child = left_node
+        node.right_child = _parse_e3(line_num, tokens)
+        left_node = node
+    return left_node
+
+def _parse_e3(line_num: int, tokens: list[ExpressionNode]) -> ExpressionNode:
+    if tokens[0].token_type in [TokenType.T_NUM, TokenType.T_LABEL]:
+        return tokens.pop(0)
+
+    _match(line_num, tokens, TokenType.T_LPAR)
+    expression = _parse_e(line_num, tokens)
+    _match(line_num, tokens, TokenType.T_RPAR)
+
+    return expression
+
+def _match(line_num: int, tokens: list[ExpressionNode], token: TokenType) -> ExpressionNode:
+    if tokens[0].token_type == token:
+        return tokens.pop(0)
+    else:
+        sys.exit(f'ERROR: line {line_num} - Invalid syntax on token: {tokens[0].token_type}')

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -17,6 +17,7 @@ class TestExpression(unittest.TestCase):
         self.assertEqual(parse_expression(1212, '(value_1 - two)/5').get_value(TestExpression.label_dict), 2, 'label expression: (value_1 - two)/5')
         self.assertEqual(parse_expression(1212, '8_ball').get_value(TestExpression.label_dict), 8, 'label expression: 8_ball')
         self.assertEqual(parse_expression(1212, '8675309').get_value(TestExpression.label_dict), 8675309, 'numeric expression: 8675309')
+        self.assertEqual(parse_expression(1212, 'value_1-2').get_value(TestExpression.label_dict), 10, 'numeric expression: value_1-2')
 
         with self.assertRaises(SystemExit, msg='only integer numeric values are supported'):
             value = parse_expression(1212, '(value_1/5)/2.4').get_value(TestExpression.label_dict)

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -1,0 +1,35 @@
+import sys
+import unittest
+
+from bespokeasm.expression import parse_expression, ExpresionType
+
+class TestExpression(unittest.TestCase):
+    label_dict = {
+            'value_1': 12,
+            '8_ball': 8,
+            'two': 2,
+        }
+
+    def test_expression_parsing(self):
+
+
+        self.assertEqual(parse_expression(1212, '1 + 2').get_value(TestExpression.label_dict), 3, 'simple expression: 1+2')
+        self.assertEqual(parse_expression(1212, '(value_1 - two)/5').get_value(TestExpression.label_dict), 2, 'label expression: (value_1 - two)/5')
+        self.assertEqual(parse_expression(1212, '8_ball').get_value(TestExpression.label_dict), 8, 'label expression: 8_ball')
+        self.assertEqual(parse_expression(1212, '8675309').get_value(TestExpression.label_dict), 8675309, 'numeric expression: 8675309')
+
+        with self.assertRaises(SystemExit, msg='only integer numeric values are supported'):
+            value = parse_expression(1212, '(value_1/5)/2.4').get_value(TestExpression.label_dict)
+
+    def test_expression_numeric_types(self):
+        self.assertEqual(parse_expression(1212, '$100/0x80').get_value(TestExpression.label_dict), 2, 'test hexadecimal math: $100/0x80')
+        self.assertEqual(parse_expression(1212, '%10000000/$2').get_value(TestExpression.label_dict), 64, 'test binary math: %1000000/$2')
+        self.assertEqual(parse_expression(1212, '32/b10').get_value(TestExpression.label_dict), 16, 'test binary math: 32/b10')
+
+    def test_expression_result_integer_casting(self):
+        # resolved values are cast to an integer, truncating the fractional part
+        self.assertEqual(parse_expression(1212, 'value_1/5').get_value(TestExpression.label_dict), 2, 'test rounding: 12/5 = 2')
+        self.assertEqual(parse_expression(1212, '10/3/2').get_value(TestExpression.label_dict), 1, 'test rounding: 10/3/2 = 1')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_line_objects.py
+++ b/test/test_line_objects.py
@@ -3,7 +3,7 @@ import unittest
 
 from bespokeasm.line_object import LineObject, LineWithBytes
 from bespokeasm.line_object.data_line import DataLine
-from bespokeasm.line_object.label_line import LabelLine
+from bespokeasm.line_object.label_line import LabelLine, is_valid_label
 from bespokeasm.line_object.instruction_line import InstructionLine, MachineCodePart
 
 class TestLineObject(unittest.TestCase):
@@ -63,6 +63,16 @@ class TestLineObject(unittest.TestCase):
         # this should fail
         with self.assertRaises(SystemExit, msg='non-numeric constant assignments should fail'):
             l3 = LabelLine.factory(13, 'my_constant = some_string', 'bad constant')
+
+    def test_valid_labels(self):
+        self.assertTrue(is_valid_label('a_str'),'valid label')
+        self.assertTrue(is_valid_label('12_monkeys'),'valid label')
+        self.assertTrue(is_valid_label('.start_with_dot'),'valid label')
+        self.assertTrue(is_valid_label('_start_with_line'),'valid label')
+
+        self.assertFalse(is_valid_label('8675309'),'invalid label: only numbers')
+        self.assertFalse(is_valid_label('m+g'),'invalid label: operators')
+        self.assertFalse(is_valid_label('final frontier'),'invalid label: contains space')
 
     def test_instruction_line_creation(self):
         isa_model = {


### PR DESCRIPTION
Added basic support to added mathematical expressions as an argument type. An expression must be resolvable to a constant integer value at compile time. It can be composed of integers, labels, parenthesis, and the `+` `-` `*` `/` math operators,