### PR TITLE
Added ability to include other source files when compiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,14 @@ Changes that are planned but not implemented yet:
 * Enable instruction aliases that allow alternative mnemonics for an instruction. For example, allowing `call` and `jsr` to mean the same thing.
 * Allow a specific operand configuration for an instruction to optionally overide the instruction's byte code
 * Allow a label to exist on the same line as an instruction or directive
-* Enable the ability to include other `asm` source files when compiling a given source file
 * add ability for source code to indicate what ISA version it needs to be compiled to.
+* Improve error checking, notably with diallowed operands or unknown labels.
 
 ## [Unreleased]
 * added some error checking on the configuration file
 * added support for local and file scoped labels. Local labels start with a `.` and are only valid between two non-local labels. File scope labels start with a `_` and are only valid within the same file they are defined.
 * added error that detects when register labels are used in numeric expresions.
+* added the ability to `#include` other `asm` source files when compiling a given source file.
 
 ## 0.1.4
 First tracked released

--- a/bespokeasm/__main__.py
+++ b/bespokeasm/__main__.py
@@ -21,7 +21,8 @@ def main():
 @click.option('--pretty-print', '-p', is_flag=True, default=False, help='if true, a pretty print version of the compilation will be produced.')
 @click.option('--pretty-print-output',  default='stdout', help='if pretty-print is enabled, this specifies the output file. Defaults to stdout.')
 @click.option('--verbose', '-v', count=True, help='Verbosity of logging')
-def compile(asm_file, config_file, output_file, binary_min_address, binary_max_address, binary_fill, pretty_print, pretty_print_output, verbose):
+@click.option('--include-path', '-I', multiple=True, default=[], help='Path to use when searching for included asm files. Multiple paths can be seperately specified.')
+def compile(asm_file, config_file, output_file, binary_min_address, binary_max_address, binary_fill, pretty_print, pretty_print_output, verbose, include_path):
     if output_file is None:
         output_file = os.path.splitext(asm_file)[0] + '.bin'
     if verbose:
@@ -37,6 +38,7 @@ def compile(asm_file, config_file, output_file, binary_min_address, binary_max_a
         int(binary_min_address), int(binary_max_address) if int(binary_max_address) >= 0 else None,
         binary_fill,
         pretty_print, pretty_print_output, verbose,
+        include_path,
     )
     asm.assemble_bytecode()
 

--- a/bespokeasm/assembler/__init__.py
+++ b/bespokeasm/assembler/__init__.py
@@ -17,15 +17,16 @@ from bespokeasm.assembler.label_scope import LabelScope, LabelScopeType
 class Assembler:
     def __init__(
             self,
-            source_file,
-            config_file,
-            output_file,
-            binary_start,
-            binary_end,
-            binary_fill_value,
-            enable_pretty_print,
-            pretty_print_output,
-            is_verbose,
+            source_file: str,
+            config_file: str,
+            output_file: str,
+            binary_start: int,
+            binary_end: int,
+            binary_fill_value: int,
+            enable_pretty_print: bool,
+            pretty_print_output: str,
+            is_verbose: int,
+            include_paths: list[str],
         ):
         self.source_file = source_file
         self._output_file = output_file
@@ -37,11 +38,12 @@ class Assembler:
         self._binary_start = binary_start
         self._binary_end = binary_end
         self._model = AssemblerModel(self._config_file, self._verbose)
+        self._include_paths = include_paths
 
     def assemble_bytecode(self):
         global_label_scope = LabelScope.global_scope(self._model.registers)
         # find base file containing directory
-        include_dirs = set([os.path.dirname(self.source_file)])
+        include_dirs = set([os.path.dirname(self.source_file)]+list(self._include_paths))
 
         asm_file = AssemblyFile(self.source_file, global_label_scope)
         line_obs = asm_file.load_line_objects(self._model, include_dirs, self._verbose)

--- a/bespokeasm/assembler/assembly_file.py
+++ b/bespokeasm/assembler/assembly_file.py
@@ -1,0 +1,18 @@
+# Assembly File
+#
+# this class models an assembly file. AN AssemblyFile object is created for each
+# assembly file that is loaded. It is responsible for:
+#
+#    * providing a list of lines
+#    * having a single file label scope
+
+from bespokeasm.assembler.label_scope import LabelScope, LabelScopeType
+
+class AssemblyFile:
+    def __init__(self, filename: str) -> None:
+        self._fielname = filename
+        self._label_scope = LabelScope(
+                LabelScopeType.FILE,
+                LabelScope.global_scope(),
+                self._fielname
+            )

--- a/bespokeasm/assembler/assembly_file.py
+++ b/bespokeasm/assembler/assembly_file.py
@@ -5,14 +5,100 @@
 #
 #    * providing a list of lines
 #    * having a single file label scope
+from __future__ import annotations
+import click
+import os
+import re
+import sys
 
 from bespokeasm.assembler.label_scope import LabelScope, LabelScopeType
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.line_object import LineObject
+from bespokeasm.assembler.line_object.directive_line import AddressOrgLine
+from bespokeasm.assembler.line_object.factory import LineOjectFactory
+from bespokeasm.assembler.line_object.label_line import LabelLine
+from bespokeasm.assembler.model import AssemblerModel
 
 class AssemblyFile:
-    def __init__(self, filename: str) -> None:
-        self._fielname = filename
+    def __init__(self, filename: str, parent_label_scope: LabelScope) -> None:
+        self._filename = filename
         self._label_scope = LabelScope(
                 LabelScopeType.FILE,
-                LabelScope.global_scope(),
-                self._fielname
+                parent_label_scope,
+                self._filename
             )
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+
+    @property
+    def label_scope(self) -> LabelScope:
+        return self._label_scope
+
+    def load_line_objects(self, isa_model: AssemblerModel, include_paths: set[str], log_verbosity: int, assembly_files_used: set = set()) -> list[LineObject]:
+        line_objects = []
+
+        with open(self.filename, 'r') as f:
+            assembly_files_used.add(self.filename)
+            line_num = 0
+            current_scope = self.label_scope
+            for  line in f:
+                line_num += 1
+                line_id = LineIdentifier(line_num, filename = self.filename)
+                line_str = line.strip()
+                if len(line_str) > 0:
+                    # check to see if this is a #include line
+                    if line_str.startswith('#include'):
+                        additional_line_objects = self._handle_include_file(line_str, line_id, isa_model, include_paths, log_verbosity, assembly_files_used)
+                        line_objects.extend(additional_line_objects)
+                        continue
+
+                    l = LineOjectFactory.parse_line(line_id, line_str, isa_model)
+                    if isinstance(l, LabelLine):
+                        if not l.is_constant and LabelScopeType.get_label_scope(l.get_label()) != LabelScopeType.LOCAL:
+                            current_scope = LabelScope(LabelScopeType.LOCAL, self.label_scope, l.get_label())
+                    elif isinstance(l, AddressOrgLine):
+                        current_scope = self.label_scope
+                    l.label_scope = current_scope
+                    line_objects.append(l)
+
+        if log_verbosity > 1:
+            click.echo(f'Found {len(line_objects)} lines in source file {self.filename}')
+
+        return line_objects
+
+    PATTERN_INCLUDE_FILE = re.compile(
+        r'^\#include\s+(?:\'|\")([\w\.]+)(?:\'|\")',
+        flags=re.IGNORECASE|re.MULTILINE
+    )
+
+    def _handle_include_file(self, line_str: int, line_id: LineIdentifier, isa_model: AssemblerModel, include_paths: set[str], log_verbosity: int, assembly_files_used: set) -> list[LineObject]:
+        label_match = re.search(AssemblyFile.PATTERN_INCLUDE_FILE, line_str)
+        if label_match is not None:
+            new_filepath = self._locate_filename(
+                    label_match.group(1).strip(),
+                    include_paths,
+                    line_id
+                )
+            if new_filepath in assembly_files_used:
+                sys.exit(f'ERROR: {line_id} - assembly file included multiple times')
+            file_obj = AssemblyFile(new_filepath, self.label_scope.parent)
+            return file_obj.load_line_objects(isa_model, include_paths, log_verbosity, assembly_files_used = assembly_files_used)
+        else:
+            sys.exit(f'ERROR: {line_id} - Improperly formatted include directive')
+
+    def _locate_filename(self, filename:str, include_paths: set[str], line_id: LineIdentifier) -> str:
+        '''locates the filename in the include paths, and returns the full file path. Errors if file name is ambiguous.'''
+        filepath = None
+        for include_dir in include_paths:
+            found_path = os.path.join(include_dir, filename)
+            if os.path.exists(found_path):
+                if filepath is None:
+                    filepath = found_path
+                else:
+                    sys.exit(f'ERROR: {line_id} - include file "{filename}" can be found multiple times in include paths')
+        if filepath is None:
+            sys.exit(f'ERROR: {line_id} - could not find file "{filename}" to include')
+        return filepath
+

--- a/bespokeasm/assembler/byte_code/assembled.py
+++ b/bespokeasm/assembler/byte_code/assembled.py
@@ -1,14 +1,15 @@
 import math
 import sys
 
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.byte_code.parts import ByteCodePart
 from bespokeasm.assembler.byte_code.packed_bits import PackedBits
 from bespokeasm.assembler.label_scope import LabelScope
 
 class AssembledInstruction:
-    def __init__(self, line_number: int, parts: list[ByteCodePart]):
+    def __init__(self, line_id: LineIdentifier, parts: list[ByteCodePart]):
         self._parts = parts
-        self._line_number = line_number
+        self._line_id = line_id
         # calculate total bytes
         total_bits = 0
         for bcp in self._parts:
@@ -27,13 +28,13 @@ class AssembledInstruction:
     def byte_size(self):
         return self._byte_size
     @property
-    def line_number(self):
-        return self._line_number
+    def line_id(self):
+        return self._line_id
 
     def get_bytes(self, label_scope: LabelScope) -> bytearray:
         packed_bits = PackedBits()
         for p in self._parts:
-            value = p.get_value(self.line_number, label_scope)
+            value = p.get_value(self.line_id, label_scope)
             if  isinstance( value, str):
                 sys.exit(f'ERROR - assembled instruction "{self}" had a part {p} that did not resolve to an int, got: {value}')
             packed_bits.append_bits(

--- a/bespokeasm/assembler/byte_code/parts.py
+++ b/bespokeasm/assembler/byte_code/parts.py
@@ -1,5 +1,6 @@
 import sys
 
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.expression import parse_expression
 
@@ -27,7 +28,7 @@ class ByteCodePart:
             self._value_size == other._value_size \
             and self._byte_align == other._byte_align \
             and self._endian == other._endian
-    def get_value(self, line_num: int, label_dict: dict[str, int]) -> int:
+    def get_value(self, line_id: LineIdentifier, label_dict: dict[str, int]) -> int:
         # this should be overridden
         return None
 
@@ -38,7 +39,7 @@ class NumericByteCodePart(ByteCodePart):
     def __str__(self):
         return f'NumericByteCodePart<value={self._value},size={self.value_size}>'
 
-    def get_value(self, line_num: int, label_dict: dict[str, int]) -> int:
+    def get_value(self, line_id: LineIdentifier, label_dict: dict[str, int]) -> int:
         return self._value
 
 class ExpressionByteCodePart(ByteCodePart):
@@ -48,10 +49,10 @@ class ExpressionByteCodePart(ByteCodePart):
     def __str__(self):
         return f'ExpressionByteCodePart<expression="{self._expression}",size={self.value_size}>'
 
-    def get_value(self, line_num: int, label_scope: LabelScope) -> int:
-        e = parse_expression(line_num, self._expression)
-        value = e.get_value(label_scope, line_num)
+    def get_value(self, line_id: LineIdentifier, label_scope: LabelScope) -> int:
+        e = parse_expression(line_id, self._expression)
+        value = e.get_value(label_scope, line_id)
         if  isinstance( value, str):
-            print(f'ERROR - expression "{self._expression}" did not resolve to an int, got: {value}')
+            print(f'ERROR: {line_id} - expression "{self._expression}" did not resolve to an int, got: {value}')
             return 0
         return value

--- a/bespokeasm/assembler/line_identifier.py
+++ b/bespokeasm/assembler/line_identifier.py
@@ -1,0 +1,18 @@
+
+
+class LineIdentifier:
+    def __init__(self, line_num: int, filename: str  = None ) -> None:
+        self._filename = filename
+        self._line_num = line_num
+
+    def __repr__(self) -> str:
+        return str(self)
+    def __str__(self) -> str:
+        return f'file {self._filename if self._filename is not None else "unnown_file"}, line {self._line_num}'
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+    @property
+    def line_num(self) -> int:
+        return self._line_num

--- a/bespokeasm/assembler/line_object/__init__.py
+++ b/bespokeasm/assembler/line_object/__init__.py
@@ -1,8 +1,9 @@
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.label_scope import LabelScope
 
 class LineObject:
-    def __init__(self, line_num: int, instruction: str, comment: str):
-        self._line_num = line_num
+    def __init__(self, line_id: LineIdentifier, instruction: str, comment: str):
+        self._line_id = line_id
         self._instruction = instruction.strip()
         self._comment = comment.strip()
         self._address = None
@@ -14,9 +15,9 @@ class LineObject:
         return f'LineObject<{self.instruction}>'
 
     @property
-    def line_number(self):
-        """Returns the line number that his object was parsed from"""
-        return self._line_num
+    def line_id(self) -> LineIdentifier:
+        """Returns the line identifier that his object was parsed from"""
+        return self._line_id
 
     def set_start_address(self, address: int):
         """Sets the address for this line object.
@@ -56,8 +57,8 @@ class LineObject:
         self._label_scope = value
 
 class LineWithBytes(LineObject):
-    def __init__(self, line_num: int, instruction: str, comment: str):
-        super().__init__(line_num, instruction, comment)
+    def __init__(self, line_id: LineIdentifier, instruction: str, comment: str):
+        super().__init__(line_id, instruction, comment)
         self._bytes = bytearray()
 
 

--- a/bespokeasm/assembler/line_object/directive_line.py
+++ b/bespokeasm/assembler/line_object/directive_line.py
@@ -1,6 +1,7 @@
 import re
 import sys
 
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineWithBytes, LineObject
 from bespokeasm.assembler.line_object.data_line import DataLine
 from bespokeasm.utilities import parse_numeric_string, is_string_numeric
@@ -20,6 +21,7 @@ class DirectiveLine:
         '.zero', 'zero', '.zerountil', 'zerountil',
         '.byte', 'byte', '.2byte', '2byte',
         '.4byte', '4byte',
+        '#include', 'include',
     ])
     PATTERN_ORG_DIRECTIVE = re.compile(
         r'^(?:\.org)\s+(\$[0-9a-f]*|0x[0-9a-f]*|b[01]*|\w*)',
@@ -41,7 +43,7 @@ class DirectiveLine:
         flags=re.IGNORECASE|re.MULTILINE
     )
 
-    def factory(line_num: int, line_str: str, comment: str, endian: str) -> LineObject:
+    def factory(line_id: LineIdentifier, line_str: str, comment: str, endian: str) -> LineObject:
         # for efficiency, if it doesn't start with a period, it is not a directive
         cleaned_line_str = line_str.strip()
         if not cleaned_line_str.startswith('.'):
@@ -51,9 +53,9 @@ class DirectiveLine:
         if line_match is not None and len(line_match.groups()) == 1:
             value_str = line_match.group(1)
             if is_string_numeric(value_str):
-                return AddressOrgLine(line_num, line_str, comment, parse_numeric_string(value_str))
+                return AddressOrgLine(line_id, line_str, comment, parse_numeric_string(value_str))
             else:
-                 sys.exit(f'ERROR: line {line_num} - .org directive value is not numeric')
+                 sys.exit(f'ERROR: {line_id} - .org directive value is not numeric')
 
         # .fill
         line_match = re.search(DirectiveLine.PATTERN_FILL_DIRECTIVE, cleaned_line_str)
@@ -62,12 +64,12 @@ class DirectiveLine:
             value_str = line_match.group(2)
             if is_string_numeric(count_str) and is_string_numeric(value_str):
                 return FillDataLine(
-                    line_num, line_str, comment,
+                    line_id, line_str, comment,
                     parse_numeric_string(count_str),
                     parse_numeric_string(value_str),
                 )
             else:
-                sys.exit(f'ERROR: line {line_num} - .fill directive values are not numeric')
+                sys.exit(f'ERROR: {line_id} - .fill directive values are not numeric')
 
         # .zero
         line_match = re.search(DirectiveLine.PATTERN_ZERO_DIRECTIVE, cleaned_line_str)
@@ -75,12 +77,12 @@ class DirectiveLine:
             count_str = line_match.group(1)
             if is_string_numeric(count_str):
                 return FillDataLine(
-                    line_num, line_str, comment,
+                    line_id, line_str, comment,
                     parse_numeric_string(count_str),
                     0,
                 )
             else:
-                sys.exit(f'ERROR: line {line_num} - .zero directive value is not numeric')
+                sys.exit(f'ERROR: {line_id} - .zero directive value is not numeric')
 
         # .zerountil
         line_match = re.search(DirectiveLine.PATTERN_ZEROUNTIL_DIRECTIVE, cleaned_line_str)
@@ -88,19 +90,19 @@ class DirectiveLine:
             address_str = line_match.group(1)
             if is_string_numeric(address_str):
                 return FillUntilDataLine(
-                    line_num, line_str, comment,
+                    line_id, line_str, comment,
                     parse_numeric_string(address_str),
                     0,
                 )
             else:
-                sys.exit(f'ERROR: line {line_num} - .zero directive value is not numeric')
+                sys.exit(f'ERROR: {line_id} - .zero directive value is not numeric')
 
         # nothing was matched here. pass to data directive
-        return DataLine.factory(line_num, line_str, comment, endian)
+        return DataLine.factory(line_id, line_str, comment, endian)
 
 class AddressOrgLine(LineObject):
-    def __init__(self, line_num: int, instruction: str, comment: str, address: int):
-        super().__init__(line_num, instruction, comment)
+    def __init__(self, line_id: LineIdentifier, instruction: str, comment: str, address: int):
+        super().__init__(line_id, instruction, comment)
         self._address = address
 
 
@@ -111,8 +113,8 @@ class AddressOrgLine(LineObject):
 
 
 class FillDataLine(LineWithBytes):
-    def __init__(self, line_num: int, instruction: str, comment: str, fill_count: int, fill_value: int):
-        super().__init__(line_num, instruction, comment)
+    def __init__(self, line_id: LineIdentifier, instruction: str, comment: str, fill_count: int, fill_value: int):
+        super().__init__(line_id, instruction, comment)
         self._bytes.extend([fill_value&0xFF]*fill_count)
 
     @property
@@ -120,8 +122,8 @@ class FillDataLine(LineWithBytes):
         return len(self._bytes)
 
 class FillUntilDataLine(LineWithBytes):
-    def __init__(self, line_num: int, instruction: str, comment: str, fill_until_address: int, fill_value: int):
-        super().__init__(line_num, instruction, comment)
+    def __init__(self, line_id: LineIdentifier, instruction: str, comment: str, fill_until_address: int, fill_value: int):
+        super().__init__(line_id, instruction, comment)
         self._fill_until_addr = fill_until_address
         self._fill_value = fill_value&0xFF
 

--- a/bespokeasm/assembler/line_object/factory.py
+++ b/bespokeasm/assembler/line_object/factory.py
@@ -1,5 +1,6 @@
 import re
 
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object.label_line import LabelLine
@@ -17,7 +18,7 @@ class LineOjectFactory:
     )
 
     @classmethod
-    def parse_line(cls, line_num: int, line_str: str, model: AssemblerModel) -> LineObject:
+    def parse_line(cls, line_id: LineIdentifier, line_str: str, model: AssemblerModel) -> LineObject:
         # find comments
         comment_str = ''
         comment_match = re.search(LineOjectFactory.PATTERN_COMMENTS, line_str)
@@ -33,20 +34,20 @@ class LineOjectFactory:
         # parse instruction
         if len(instruction_str) > 0:
             # try label
-            line_obj = LabelLine.factory(line_num, instruction_str, comment_str, model.registers)
+            line_obj = LabelLine.factory(line_id, instruction_str, comment_str, model.registers)
             if line_obj is not None:
                 return line_obj
 
             # try directives
-            line_obj = DirectiveLine.factory(line_num, instruction_str, comment_str, model.endian)
+            line_obj = DirectiveLine.factory(line_id, instruction_str, comment_str, model.endian)
             if line_obj is not None:
                 return line_obj
 
             # try instruction
-            line_obj = InstructionLine.factory(line_num, instruction_str, comment_str, model)
+            line_obj = InstructionLine.factory(line_id, instruction_str, comment_str, model)
             if line_obj is not None:
                 return line_obj
 
         # if we got here, the line is only a comment
-        line_obj = LineObject(line_num, instruction_str, comment_str)
+        line_obj = LineObject(line_id, instruction_str, comment_str)
         return line_obj

--- a/bespokeasm/assembler/line_object/instruction_line.py
+++ b/bespokeasm/assembler/line_object/instruction_line.py
@@ -1,6 +1,7 @@
 import re
 import sys
 
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineWithBytes
 from bespokeasm.assembler.model import AssemblerModel
 
@@ -8,32 +9,32 @@ from bespokeasm.assembler.model import AssemblerModel
 class InstructionLine(LineWithBytes):
     COMMAND_EXTRACT_PATTERN = re.compile(r'^\s*(\w+)', flags=re.IGNORECASE|re.MULTILINE)
 
-    def factory(line_num: int, line_str: str, comment: str, isa_model: AssemblerModel):
+    def factory(line_id: LineIdentifier, line_str: str, comment: str, isa_model: AssemblerModel):
         """Tries to contruct a instruction line object from the passed instruction line"""
         #extract the instruction command
         command_match = re.search(InstructionLine.COMMAND_EXTRACT_PATTERN, line_str)
         if command_match is None or len(command_match.groups()) != 1:
-            sys.exit(f'ERROR: line {line_num} - Wrongly formatted instruction: {line_str}')
+            sys.exit(f'ERROR: {line_id} - Wrongly formatted instruction: {line_str}')
         command_str = command_match.group(1).strip()
         if command_str not in isa_model.instruction_mnemonics:
-            sys.exit(f'ERROR: line {line_num} - Unreconized instruction: {line_str}')
+            sys.exit(f'ERROR: {line_id} - Unreconized instruction: {line_str}')
         argument_str = line_str.strip()[len(command_str):]
-        return InstructionLine(line_num, command_str, argument_str, isa_model, line_str, comment)
+        return InstructionLine(line_id, command_str, argument_str, isa_model, line_str, comment)
 
     def __init__(
             self,
-            line_num: int,
+            line_id: LineIdentifier,
             command_str: str,
             argument_str: str,
             isa_model: AssemblerModel,
             instruction: str,
             comment: str
         ):
-        super().__init__(line_num, instruction, comment)
+        super().__init__(line_id, instruction, comment)
         self._command = command_str
         self._argument_str = argument_str
         self._isa_model = isa_model
-        self._assembled_instruction = self._isa_model.parse_instruction(line_num, instruction)
+        self._assembled_instruction = self._isa_model.parse_instruction(line_id, instruction)
     def __str__(self):
         return f'InstructionLine<{self.instruction.strip()} -> {self._assembled_instruction}>'
 

--- a/bespokeasm/assembler/model/__init__.py
+++ b/bespokeasm/assembler/model/__init__.py
@@ -3,6 +3,7 @@ import sys
 import yaml
 
 from bespokeasm import BESPOKEASM_VERSION_STR, BESPOKEASM_MIN_REQUIRED_STR
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.byte_code.assembled import AssembledInstruction
 from bespokeasm.assembler.model.instruction_set import InstructionSet
 from bespokeasm.assembler.model.operand_set import OperandSet, OperandSetCollection
@@ -67,7 +68,7 @@ class AssemblerModel:
     def get_operand_set(self, operand_set_name: str) -> OperandSet:
         return self._operand_sets.get_operand_set(operand_set_name)
 
-    def parse_instruction(self, line_num: int, instruction: str) -> AssembledInstruction:
+    def parse_instruction(self, line_id: LineIdentifier, instruction: str) -> AssembledInstruction:
         instr_parts = instruction.strip().split(' ', 1)
         mnemonic = instr_parts[0].lower()
         if len(instr_parts) > 1:
@@ -77,5 +78,5 @@ class AssemblerModel:
 
         instr_obj = self._instructions.get(mnemonic)
         if instr_obj is None:
-            sys.exit(f'ERROR: line {line_num} - Unrecognized mnemonic "{mnemonic}"')
-        return instr_obj.generate_bytecode_parts(line_num, mnemonic, operands, self.endian)
+            sys.exit(f'ERROR: {line_id} - Unrecognized mnemonic "{mnemonic}"')
+        return instr_obj.generate_bytecode_parts(line_id, mnemonic, operands, self.endian)

--- a/bespokeasm/assembler/model/instruction.py
+++ b/bespokeasm/assembler/model/instruction.py
@@ -1,5 +1,6 @@
 import sys
 
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.byte_code.assembled import AssembledInstruction
 from bespokeasm.assembler.model.operand_parser import OperandParser
 from bespokeasm.assembler.model.operand_set import OperandSetCollection
@@ -43,10 +44,10 @@ class Instruction:
     def base_bytecode_value(self) -> int:
         return self._config['byte_code']['value']
 
-    def generate_bytecode_parts(self, line_num: int, mnemonic: str, operands: str, default_endian: str) -> AssembledInstruction:
+    def generate_bytecode_parts(self, line_id: LineIdentifier, mnemonic: str, operands: str, default_endian: str) -> AssembledInstruction:
         if mnemonic != self.mnemonic:
             # this shouldn't happen
-            sys.exit(f'ERROR: line {line_num} - INTERNAL - Asked instruction {self} to parse mnemonic "{mnemonic}"')
+            sys.exit(f'ERROR: {line_id} - INTERNAL - Asked instruction {self} to parse mnemonic "{mnemonic}"')
         if operands is not None and operands != '':
             operand_list = operands.strip().split(',')
         else:
@@ -57,13 +58,13 @@ class Instruction:
         machine_code = [NumericByteCodePart(self.base_bytecode_value, self.base_bytecode_size, True, instruction_endian)]
 
 
-        operand_bytecode, operand_arguments = self._operand_parser.generate_machine_code(line_num, operand_list)
+        operand_bytecode, operand_arguments = self._operand_parser.generate_machine_code(line_id, operand_list)
         if operand_bytecode is not None:
             machine_code.extend(operand_bytecode)
         if operand_arguments is not None:
             machine_code.extend(operand_arguments)
 
-        return AssembledInstruction(line_num, machine_code)
+        return AssembledInstruction(line_id, machine_code)
 
 
 

--- a/bespokeasm/assembler/model/operand_set.py
+++ b/bespokeasm/assembler/model/operand_set.py
@@ -1,5 +1,6 @@
 import sys
 
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.model.operand import Operand
 from bespokeasm.assembler.byte_code.parts import ByteCodePart
 
@@ -30,9 +31,9 @@ class OperandSet:
     def default_bytecode_size(self) -> int:
         return self._config.get('bytecode_size', None)
 
-    def parse_operand(self,line_num: int, operand_str: str) -> tuple[str, ByteCodePart, ByteCodePart]:
+    def parse_operand(self, line_id: LineIdentifier, operand_str: str) -> tuple[str, ByteCodePart, ByteCodePart]:
         for operand in self._ordered_operand_list:
-            bytecode_part, argument_part = operand.parse_operand(line_num, operand_str)
+            bytecode_part, argument_part = operand.parse_operand(line_id, operand_str)
             if bytecode_part is not None or argument_part is not None:
                 # if some part was returned, then this is a valid match. Matching
                 # precedence order is important here!

--- a/bespokeasm/expression/__init__.py
+++ b/bespokeasm/expression/__init__.py
@@ -13,6 +13,7 @@ import re
 import sys
 
 from bespokeasm.utilities import is_string_numeric, parse_numeric_string
+from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.assembler.line_object.label_line import is_valid_label
 
@@ -52,43 +53,42 @@ class ExpressionNode:
     def __str__(self):
         return f'<ExpressionNode: type={self.token_type}, value="{self.value}">'
 
-    def _numeric_value(self, label_scope: LabelScope, line_num: int) -> int:
+    def _numeric_value(self, label_scope: LabelScope, line_id: LineIdentifier) -> int:
         if self.token_type == TokenType.T_NUM:
             return self.value
         elif self.token_type == TokenType.T_LABEL:
             # in ths case value is a label
-            val = label_scope.get_label_value(self.value, line_num)
+            val = label_scope.get_label_value(self.value, line_id)
             if val is None:
-                print(f'Label resolves to NONE = {self}')
+                sys.exit(f'ERROR: {line_id} - Label {self.value} resolves to NONE = {self}')
             return val
         else:
             # this wasn't a numeric value
-            print(f'NOT Numeric = {self}')
-            return None
+            sys.exit(f'ERROR: {line_id} - Label {self.value} is not numeric = {self}')
 
-    def _compute(self, label_scope: LabelScope, line_num: int) -> float:
+    def _compute(self, label_scope: LabelScope, line_id: LineIdentifier) -> float:
         if self.token_type in [TokenType.T_NUM, TokenType.T_LABEL]:
-            return float(self._numeric_value(label_scope, line_num))
-        left_result = self.left_child._compute(label_scope, line_num)
-        right_result = self.right_child._compute(label_scope, line_num)
+            return float(self._numeric_value(label_scope, line_id))
+        left_result = self.left_child._compute(label_scope, line_id)
+        right_result = self.right_child._compute(label_scope, line_id)
         operation = ExpressionNode._operations[self.token_type]
         if self.token_type in [TokenType.T_AND, TokenType.T_OR, TokenType.T_XOR]:
             left_result = int(left_result)
             right_result = int(right_result)
         return operation(left_result, right_result)
 
-    def get_value(self, label_scope: LabelScope, line_num: int) -> int:
-        return int(self._compute(label_scope, line_num))
+    def get_value(self, label_scope: LabelScope, line_id: LineIdentifier) -> int:
+        return int(self._compute(label_scope, line_id))
 
 ExpresionType = ExpressionNode
 
-def parse_expression(line_num: int, expression: str) -> ExpresionType:
-    tokens = _lexical_analysis(line_num, expression)
-    ast = _parse_e(line_num, tokens)
-    _match(line_num, tokens, TokenType.T_END)
+def parse_expression(line_id: LineIdentifier, expression: str) -> ExpresionType:
+    tokens = _lexical_analysis(line_id, expression)
+    ast = _parse_e(line_id, tokens)
+    _match(line_id, tokens, TokenType.T_END)
     return ast
 
-def _lexical_analysis(line_num: int, s: str) -> list[ExpressionNode]:
+def _lexical_analysis(line_id: LineIdentifier, s: str) -> list[ExpressionNode]:
     mappings = {
         '+': TokenType.T_PLUS,
         '-': TokenType.T_MINUS,
@@ -112,50 +112,50 @@ def _lexical_analysis(line_num: int, s: str) -> list[ExpressionNode]:
         elif is_valid_label(part):
             token = ExpressionNode(TokenType.T_LABEL, value=part)
         else:
-            sys.exit(f'ERROR: line {line_num} - invalid token: {part}')
+            sys.exit(f'ERROR: {line_id} - invalid token: {part}')
         tokens.append(token)
     tokens.append(ExpressionNode(TokenType.T_END))
     return tokens
 
-def _parse_e(line_num: int, tokens: list[ExpressionNode]) -> ExpressionNode:
-    left_node = _parse_e1(line_num, tokens)
+def _parse_e(line_id: LineIdentifier, tokens: list[ExpressionNode]) -> ExpressionNode:
+    left_node = _parse_e1(line_id, tokens)
     while tokens[0].token_type in [TokenType.T_AND, TokenType.T_OR, TokenType.T_XOR]:
         node = tokens.pop(0)
         node.left_child = left_node
-        node.right_child = _parse_e1(line_num, tokens)
+        node.right_child = _parse_e1(line_id, tokens)
         left_node = node
     return left_node
 
-def _parse_e1(line_num: int, tokens: list[ExpressionNode]) -> ExpressionNode:
-    left_node = _parse_e2(line_num, tokens)
+def _parse_e1(line_id: LineIdentifier, tokens: list[ExpressionNode]) -> ExpressionNode:
+    left_node = _parse_e2(line_id, tokens)
     while tokens[0].token_type in [TokenType.T_PLUS, TokenType.T_MINUS]:
         node = tokens.pop(0)
         node.left_child = left_node
-        node.right_child = _parse_e2(line_num, tokens)
+        node.right_child = _parse_e2(line_id, tokens)
         left_node = node
     return left_node
 
-def _parse_e2(line_num: int, tokens: list[ExpressionNode]) -> ExpressionNode:
-    left_node = _parse_e3(line_num, tokens)
+def _parse_e2(line_id: LineIdentifier, tokens: list[ExpressionNode]) -> ExpressionNode:
+    left_node = _parse_e3(line_id, tokens)
     while tokens[0].token_type in [TokenType.T_MULT, TokenType.T_DIV]:
         node = tokens.pop(0)
         node.left_child = left_node
-        node.right_child = _parse_e3(line_num, tokens)
+        node.right_child = _parse_e3(line_id, tokens)
         left_node = node
     return left_node
 
-def _parse_e3(line_num: int, tokens: list[ExpressionNode]) -> ExpressionNode:
+def _parse_e3(line_id: LineIdentifier, tokens: list[ExpressionNode]) -> ExpressionNode:
     if tokens[0].token_type in [TokenType.T_NUM, TokenType.T_LABEL]:
         return tokens.pop(0)
 
-    _match(line_num, tokens, TokenType.T_LPAR)
-    expression = _parse_e(line_num, tokens)
-    _match(line_num, tokens, TokenType.T_RPAR)
+    _match(line_id, tokens, TokenType.T_LPAR)
+    expression = _parse_e(line_id, tokens)
+    _match(line_id, tokens, TokenType.T_RPAR)
 
     return expression
 
-def _match(line_num: int, tokens: list[ExpressionNode], token: TokenType) -> ExpressionNode:
+def _match(line_id: LineIdentifier, tokens: list[ExpressionNode], token: TokenType) -> ExpressionNode:
     if tokens[0].token_type == token:
         return tokens.pop(0)
     else:
-        sys.exit(f'ERROR: line {line_num} - Invalid syntax on token: {tokens[0]}')
+        sys.exit(f'ERROR: {line_id} - Invalid syntax on token: {tokens[0]}')


### PR DESCRIPTION
Added the `#include` directive which allows the main assembly file being compiled to be able to include other assembly files into the compilation. Basic error checking is enabled, notably looking for overlapping byte code. 

Basic syntax is:
```asm
#include "other.asm"

init:
    mov a, $80

    ...
```
The `#include` directive can be anywhere, and the address assignment of the included file will start at the inclusion point. `.org` directives can be used to ensure certain byte code is at certain locations. 

Directories to use for the include search path can be specified on the command line with the `-I` option.