### PR TITLE
Enable Syntax Highlighting for Visual Studio Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Changes that are planned but not implemented yet:
   * missing `:` after labels
   * unknown labels
 
+## [0.1.7]
+* Added ability to generate a language extension with syntax highlighting for Visual Code Studio
+
 ## [0.1.6]
 * Added `indirect index register` addressing mode.
 * Fixed a bug in parsing binary numbers assigned to constants
@@ -39,6 +42,7 @@ First tracked released
 * Enabled the `reverse_argument_order` instruction option be applied to a specific operand configuration. This slightly changed the configuration file format.
 * Added ability for instructions with operands to have a single "empty operand" variant, e.g., `pop`
 
-[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.1.7...HEAD
+[0.1.7]: https://github.com/michaelkamprath/bespokeasm/compare/v0.1.7...v0.1.6
 [0.1.6]: https://github.com/michaelkamprath/bespokeasm/compare/v0.1.6...v0.1.5
 [0.1.5]: https://github.com/michaelkamprath/bespokeasm/compare/v0.1.5...v0.1.4

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Once installed, assembly code can be compiled in this manner:
 
 Note that supplying an instruction set configuration file is required via the `-c` option. The binary byte code image will be written to `<asm-file-basename>.bin`, though this can be changed with the `-o` option. Add `--pretty-print` to the command to get a human readable output.
 
+### Installing Systax Highlighting
+BespokeASM can generate a sytax highlighting extension for [Visual Studio Code](https://code.visualstudio.com) that will properly highlight the instruction mnomics and other aspects of the assembly language configured in the instruction set architecture configuration file. To install:
+```sh
+bespokeasm generate-extension vscode -c isa-config.yaml
+```
+
 # Documentation
 Documentation is availabe on the [Bespoke ASM Wiki](https://github.com/michaelkamprath/bespokeasm/wiki).
 

--- a/bespokeasm/__init__.py
+++ b/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = "0.1.6"
+BESPOKEASM_VERSION_STR = "0.1.7"
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = "0.1.4"

--- a/bespokeasm/__main__.py
+++ b/bespokeasm/__main__.py
@@ -4,6 +4,7 @@ import sys
 
 from bespokeasm import BESPOKEASM_VERSION_STR
 from bespokeasm.assembler import Assembler
+from bespokeasm.configgen.vscode import VSCodeConfigGenerator
 
 @click.group()
 @click.version_option(BESPOKEASM_VERSION_STR)
@@ -11,7 +12,7 @@ def main():
     """A Bespoke ISA Assembler"""
     pass
 
-@main.command()
+@main.command(short_help='compile an assembly file into bytecode')
 @click.argument('asm_file')
 @click.option('--config-file', '-c', required=True, help='The filepath to the instruction set configuration file,')
 @click.option('--output-file', '-o', help='The filepath to where the binary image will be written. Defaults to the input file name with a *.bin extension.')
@@ -41,6 +42,24 @@ def compile(asm_file, config_file, output_file, binary_min_address, binary_max_a
         include_path,
     )
     asm.assemble_bytecode()
+
+@main.group(short_help='generate a language syntax highlighting extension')
+def generate_extension():
+    pass
+
+
+@generate_extension.command(short_help='generate for VisualStudio Code')
+@click.option('--config-file', '-c', required=True, help='The filepath to the instruction set configuration file,')
+@click.option('--verbose', '-v', count=True, help='Verbosity of logging')
+@click.option('--vscode-config-dir', '-d', default='~/.vscode/', help="The file path the Visual Studo Code configuration directory containing the extensions directory.")
+@click.option('--language-name', '-l', help="The name of the language in the Visual Studio Code configuration file. Defaults to value provide in instruction set configuration file.")
+@click.option('--language-version', '-k', help="The version of the language in the Visual Studio Code configuration file. Defaults to value provide in instruction set configuration file.")
+@click.option('--code-extension', '-x', default='asm', help="The file extension for aassembly code files for this languuage configuraton.")
+def vscode(config_file, verbose, vscode_config_dir, language_name, language_version, code_extension):
+    config_file = os.path.abspath(os.path.expanduser(config_file))
+    vscode_config_dir = os.path.abspath(os.path.expanduser(vscode_config_dir))
+    generator = VSCodeConfigGenerator(config_file, verbose, vscode_config_dir, language_name, language_version, code_extension)
+    generator.generate()
 
 if __name__ == '__main__':
     args = sys.argv

--- a/bespokeasm/configgen/__init__.py
+++ b/bespokeasm/configgen/__init__.py
@@ -1,0 +1,14 @@
+
+from bespokeasm.assembler.model import AssemblerModel
+
+class LanguageConfigGenerator:
+    def __init__(self, config_file_path: str, is_verbose: int) -> None:
+        self._model = AssemblerModel(config_file_path, is_verbose)
+        self._verbose = is_verbose
+
+    @property
+    def model(self) -> AssemblerModel:
+        return self._model
+    @property
+    def verbose(self) -> int:
+        return self._verbose

--- a/bespokeasm/configgen/vscode/__init__.py
+++ b/bespokeasm/configgen/vscode/__init__.py
@@ -1,0 +1,105 @@
+import importlib.resources as pkg_resources
+import json
+import os
+from pathlib import Path
+import shutil
+
+from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.configgen import LanguageConfigGenerator
+import bespokeasm.configgen.vscode.resources as resources
+
+class VSCodeConfigGenerator(LanguageConfigGenerator):
+    def __init__(
+            self,
+            config_file_path: str,
+            is_verbose: int,
+            vscode_config_dir: str,
+            language_name: str,
+            language_version: str,
+            code_extension: str,
+        ) -> None:
+        super().__init__(config_file_path, is_verbose)
+        self._vscode_config_dir = vscode_config_dir
+        self._language_name = self.model.isa_name
+        self._language_version = self.model.isa_version
+        self._code_extension = code_extension
+
+    @property
+    def vscode_config_dir(self) -> str:
+        return self._vscode_config_dir
+    @property
+    def language_name(self) -> str:
+        return self._language_name
+    @property
+    def language_version(self) -> str:
+        return self._language_version
+    @property
+    def code_extension(self) -> str:
+        return self._code_extension
+
+    def generate(self) -> None:
+        extension_name = self.language_name
+        extension_dir_path = os.path.join(self.vscode_config_dir, 'extensions', extension_name)
+        language_id = self.language_name + '-assembly'
+
+        if self.verbose >= 1:
+            print(f'Generating Visual Studio Code extension for language "{language_id}" at: {extension_dir_path}')
+
+        # create the extensions directory if it doesn't exist
+        Path(extension_dir_path).mkdir(parents=True, exist_ok=True)
+        Path(os.path.join(extension_dir_path, 'syntaxes')).mkdir(parents=True, exist_ok=True)
+        # generate package.json
+        with pkg_resources.path(resources, 'package.json') as fp:
+            with open(fp, 'r') as json_file:
+                package_json = json.load(json_file)
+
+        package_json['name'] = self.language_name
+        package_json['version'] = self.language_version
+        package_json['contributes']['languages'][0]['id'] = language_id
+        package_json['contributes']['languages'][0]['extensions'] = ['.'+self.code_extension]
+        package_json['contributes']['grammars'][0]['language'] = language_id
+        package_json['contributes']['snippets'][0]['language'] = language_id
+        package_fp = os.path.join(extension_dir_path, 'package.json')
+        with open(package_fp, 'w', encoding='utf-8') as f:
+            json.dump(package_json, f, ensure_ascii=False, indent=4)
+        if self.verbose > 2:
+            print(f'package.json = {json.dumps(package_json, indent=4)}')
+
+        # generate tmGrammar.json
+        with pkg_resources.path(resources, 'tmGrammar.json') as fp:
+            with open(fp, 'r') as json_file:
+                grammar_json = json.load(json_file)
+
+        instructions_str: str = grammar_json['repository']['instructions']['match']
+        instructions_regex = '|'.join(self.model.instruction_mnemonics)
+        grammar_json['repository']['instructions']['match'] = instructions_str.replace('##INSTRUCTIONS##', instructions_regex)
+        if len(self.model.registers) > 0:
+            # update the registers syntax
+            registers_str: str = grammar_json['repository']['registers']['match']
+            registers_regex = '|'.join(self.model.registers)
+            grammar_json['repository']['registers']['match'] = registers_str.replace('##REGISTERS##', registers_regex)
+        else:
+            # remove the registers syntax
+            del grammar_json['repository']['registers']
+        tmGrammar_fp = os.path.join(extension_dir_path, 'syntaxes', 'tmGrammar.json')
+        with open(tmGrammar_fp, 'w', encoding='utf-8') as f:
+            json.dump(grammar_json, f, ensure_ascii=False, indent=4)
+        if self.verbose > 2:
+            print(f'\ntmGrammar.json = {json.dumps(grammar_json, indent=4)}')
+
+        # copy snippets.json and lanaguage-configuration.json, nothing to modify
+        with pkg_resources.path(resources, 'snippets.json') as fp:
+            shutil.copy(str(fp), extension_dir_path)
+            if self.verbose > 2:
+                with open(fp, 'r') as json_file:
+                    json_obj = json.load(json_file)
+                    print(f'\nsnippets.json = {json.dumps(json_obj, indent=4)}')
+
+        with pkg_resources.path(resources, 'language-configuration.json') as fp:
+            shutil.copy(str(fp), extension_dir_path)
+            if self.verbose > 2:
+                with open(fp, 'r') as json_file:
+                    json_obj = json.load(json_file)
+                    print(f'\nlanguage-configuration.json = {json.dumps(json_obj, indent=4)}')
+
+

--- a/bespokeasm/configgen/vscode/resources/language-configuration.json
+++ b/bespokeasm/configgen/vscode/resources/language-configuration.json
@@ -1,0 +1,35 @@
+{
+	"comments": {
+		"lineComment": ";",
+		"blockComment": [ ";", ";" ]
+	},
+    "brackets": [
+        ["[", "]"],
+        ["(", ")"]
+    ],
+    "autoClosingPairs": [
+        { "open": "[", "close": "]" },
+        { "open": "(", "close": ")" },
+        { "open": "'", "close": "'", "notIn": ["string", "comment"] },
+        { "open": "\"", "close": "\"", "notIn": ["string"] }
+    ],
+    "surroundingPairs": [
+        ["[", "]"],
+        ["(", ")"],
+        ["'", "'"],
+        ["\"", "\""]
+    ],
+    "onEnterRules": [
+        {
+            "beforeText": "^\\s*(?:\\.|_|\\w){1}[\\w\\d_]*(?:\\:)",
+            "action": { "indent": "indent" }
+        },
+        {
+            "beforeText": "^\\;.*$",
+            "action": {
+                "indent": "none",
+                "appendText": "; "
+            }
+        }
+    ]
+}

--- a/bespokeasm/configgen/vscode/resources/package.json
+++ b/bespokeasm/configgen/vscode/resources/package.json
@@ -1,0 +1,25 @@
+{
+    "name": "putey-assembly",
+    "version": "0.0.1",
+    "engines": {
+        "vscode": ">=0.9.0-pre.1"
+    },
+    "publisher": "bespokeasm",
+    "contributes": {
+        "languages": [{
+            "id": "putey1-assembly",
+            "extensions": [".asm"],
+            "configuration": "./language-configuration.json"
+        }],
+        "grammars": [{
+            "language": "putey1-assembly",
+            "scopeName": "source.asm",
+            "path": "./syntaxes/tmGrammar.json"
+        }],
+        "snippets": [{
+            "language": "putey1-assembly",
+            "path": "./snippets.json"
+        }]
+    },
+    "categories": ["Snippets"]
+}

--- a/bespokeasm/configgen/vscode/resources/snippets.json
+++ b/bespokeasm/configgen/vscode/resources/snippets.json
@@ -1,0 +1,7 @@
+{
+    "cstr": {
+        "prefix": [".cstr", "cstr"],
+        "body": [".cstr \"$1\""],
+        "description": "A null-terminated string"
+    }
+}

--- a/bespokeasm/configgen/vscode/resources/tmGrammar.json
+++ b/bespokeasm/configgen/vscode/resources/tmGrammar.json
@@ -1,0 +1,153 @@
+{
+    "scopeName": "source.asm",
+    "patterns": [{ "include": "#expression" }],
+    "repository": {
+        "expression": {
+            "patterns": [
+                { "include": "#instructions" },
+                { "include": "#registers" },
+                { "include": "#labels" },
+                { "include": "#constants" },
+                { "include": "#comments" },
+                { "include": "#numeric-values" },
+                { "include": "#operators" },
+                { "include": "#expressions" },
+                { "include": "#indirect-addressing"},
+                { "include": "#directives" },
+                { "include": "#strings" }
+            ]
+        },
+        "instructions": {
+            "name": "entity.name.function.instruction",
+            "match": "\\b(?:##INSTRUCTIONS##)\\b"
+        },
+        "registers": {
+            "name": "variable.language.register",
+            "match": "\\b(?:##REGISTERS##)\\b"
+        },
+        "labels": {
+            "match": "((?:\\.|_|\\w){1}[\\w\\d_]*)(\\:)",
+            "captures": {
+                "1": { "name": "variable.other.label" },
+                "2": { "name": "punctuation.separator" }
+            }
+        },
+        "constants": {
+            "name": "variable.other.constant",
+            "match": "^\\s*(\\w*)(?:\\s*)?(?=\\=)"
+        },
+        "comments": {
+            "name": "comment.line.semicolon",
+            "begin": "\\;",
+            "end": "\\n"
+        },
+        "numeric-values": {
+            "patterns": [
+                {
+                    "name": "constant.numeric.integer.hexadecimal",
+                    "match": "(?<!\\w)(?:\\$[0-9a-fA-F]+|0x[0-9a-fA-F]+)\\b"
+                },
+                {
+                    "name": "constant.numeric.integer.binary",
+                    "match": "(?<!\\w)(?:(?:b|%)[01]+)\\b"
+                },
+                {
+                    "name": "constant.numeric.integer.decimal",
+                    "match": "(?<!\\w)(?:\\d+)\\b"
+                }
+            ]
+        },
+        "operators": {
+            "patterns": [
+                {
+                    "name": "keyword.operator.arithmetic",
+                    "match": "\\b[\\+\\-\\*\\/]{1}\\b"
+                },
+                {
+                    "name": "keyword.operator.logical",
+                    "match": "\\b[\\&\\|\\^]{1}\\b"
+                }
+            ]
+        },
+        "expressions": {
+            "name": "meta.parens",
+             "patterns": [
+                { "include": "#numeric-values" },
+                { "include": "#operators" }
+            ],
+            "begin": "\\(",
+            "end": "\\)",
+            "beginCaptures": {
+                "0": { "name": "punctuation.section.parens.begin" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.section.parens.end" }
+            },
+            "contentName": "expression.group"
+        },
+        "indirect-addressing": {
+            "name": "meta.brackets",
+            "patterns": [
+                { "include": "#registers" },
+                { "include": "#numeric-values" },
+                { "include": "#expressions" },
+                { "include": "#indirect-addressing" },
+                { "include": "#operators" }
+            ],
+            "begin": "\\[",
+            "end": "\\]",
+            "beginCaptures": {
+                "0": { "name": "punctuation.section.brackets.begin" }
+            },
+            "endCaptures": {
+                "0": { "name": "punctuation.section.brackets.end" }
+            },
+            "contentName": "expression.indirect_addressing"
+        },
+        "directives": {
+            "patterns": [
+                {
+                    "name": "keyword.other.directive",
+                    "match": "\\.org|\\.fill|\\.zero|\\.zerountil"
+                },
+                {
+                    "name": "storage.type",
+                    "match": "\\.byte|\\.2byte|\\.4byte|\\.cstr"
+                },
+                {
+                    "begin": "^\\s*[#]\\s*(include)\\b\\s+",
+                    "beginCaptures": {
+                        "1": { "name": "keyword.control.import.include" }
+                    },
+                    "end": "(?=(?://|/\\*))|$",
+                    "name": "meta.preprocessor",
+                    "patterns": [
+                        {
+                            "name": "string.quoted.double.include",
+                            "begin": "\\\"",
+                            "beginCaptures": {
+                                "0": { "name": "punctuation.definition.string.begin" }
+                            },
+                            "end": "\\\"",
+                            "endCaptures": {
+                                "0": { "name": "punctuation.definition.string.end" }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "strings": {
+            "name": "meta.string",
+            "begin": "(\\\"|\\')",
+            "beginCaptures": {
+                "0": { "name": "punctuation.definition.string.begin" }
+            },
+            "end": "(?<!\\\\)\\1",
+            "endCaptures": {
+                "0": { "name": "punctuation.definition.string.end" }
+            },
+            "contentName": "string.quoted"
+        }
+    }
+}

--- a/examples/eater-sap1-isa.yaml
+++ b/examples/eater-sap1-isa.yaml
@@ -2,6 +2,9 @@ description: Eater SAP-1 ISA
 general:
   min_version: 0.1.4
   address_size: 4
+  identifier:
+    name: eater-sap1
+    version: "1.0.0"
 operand_sets:
   integer:
     operand_values:

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup (
     description = 'A customizable byte code assembler that allows for the definition of custom instruction set architecture',
     version = BESPOKEASM_VERSION_STR,
     packages = find_packages(), # list of all packages
+    package_data={'': ['*.json']},
     install_requires = install_requires,
     python_requires='>=3.9',
     entry_points='''

--- a/test/config_files/test_indirect_indexed_register_operands.yaml
+++ b/test/config_files/test_indirect_indexed_register_operands.yaml
@@ -11,6 +11,9 @@ general:
     - hl
     - sp
     - mar
+  identifier:
+    name: tester-assembly
+    version: "0.3.0"
 operand_sets:
   8_bit_source:
     operand_values:

--- a/test/config_files/test_instruction_line_creation_little_endian.yaml
+++ b/test/config_files/test_instruction_line_creation_little_endian.yaml
@@ -2,6 +2,9 @@
 general :
   address_size: 16
   endian: little
+  identifier:
+    name: bespokeasm-test
+    version: "0.3.0"
 registers:
 operand_sets:
   2byte_value:

--- a/test/test_configgen.py
+++ b/test/test_configgen.py
@@ -1,0 +1,112 @@
+import json
+import importlib.resources as pkg_resources
+import os
+import pathlib as pl
+import re
+import shutil
+import tempfile
+import unittest
+
+from test import config_files
+
+from bespokeasm.configgen.vscode import VSCodeConfigGenerator
+
+class TestConfigurationGeneration(unittest.TestCase):
+
+    def assertIsFile(self, path):
+        if not pl.Path(path).resolve().is_file():
+            raise AssertionError("File does not exist: %s" % str(path))
+
+    def test_vscode_configgen_no_registers(self):
+        test_dir = tempfile.mkdtemp()
+        with pkg_resources.path(config_files, 'test_instruction_line_creation_little_endian.yaml') as config_file:
+            configgen = VSCodeConfigGenerator(
+                str(config_file),
+                0,
+                str(test_dir),
+                None,
+                None,
+                'asmtest',
+            )
+
+        self.assertEqual(configgen.model.isa_name, 'bespokeasm-test', 'name should be in ISA config')
+
+        configgen.generate()
+
+        extension_dirpath = os.path.join(str(test_dir), 'extensions')
+
+        package_fp = os.path.join(extension_dirpath, 'bespokeasm-test', 'package.json')
+        self.assertIsFile(package_fp)
+        with open(package_fp, 'r') as json_file:
+            package_json = json.load(json_file)
+        self.assertEqual(package_json['name'], 'bespokeasm-test', 'package name should be modified ISA name')
+        self.assertEqual(package_json['contributes']['languages'][0]['id'], 'bespokeasm-test-assembly', 'language ID should be modified ISA name')
+        self.assertEqual(package_json['contributes']['languages'][0]['extensions'], ['.asmtest'], 'file extension list should match')
+        self.assertEqual(package_json['contributes']['grammars'][0]['language'], 'bespokeasm-test-assembly', 'language ID should be modified ISA name')
+        self.assertEqual(package_json['contributes']['snippets'][0]['language'], 'bespokeasm-test-assembly', 'language ID should be modified ISA name')
+        self.assertEqual(package_json['contributes']['snippets'][0]['language'], 'bespokeasm-test-assembly', 'language ID should be modified ISA name')
+
+        grammar_fp = os.path.join(extension_dirpath, 'bespokeasm-test', 'syntaxes', 'tmGrammar.json')
+        self.assertIsFile(grammar_fp)
+        with open(grammar_fp, 'r') as json_file:
+            grammar_json = json.load(json_file)
+        instruction_str = grammar_json['repository']['instructions']['match']
+        instruction_match = re.search(r'\(\?\:(.*)\)', instruction_str, re.IGNORECASE)
+        self.assertIsNotNone(instruction_match, 'instruction match should be found')
+        instruction_list = set(instruction_match.group(1).split('|'))
+        self.assertSetEqual(instruction_list, set(['lda', 'add', 'set', 'big', 'hlt']), 'all instructions should be found')
+        self.assertFalse(('registers' in grammar_json['repository']), 'no registers should be found')
+
+        self.assertIsFile(os.path.join(extension_dirpath, 'bespokeasm-test', 'snippets.json'))
+        self.assertIsFile(os.path.join(extension_dirpath, 'bespokeasm-test', 'language-configuration.json'))
+
+        shutil.rmtree(test_dir)
+
+    def test_vscode_configgen_with_registers(self):
+        test_dir = tempfile.mkdtemp()
+        with pkg_resources.path(config_files, 'test_indirect_indexed_register_operands.yaml') as config_file:
+            configgen = VSCodeConfigGenerator(
+                str(config_file),
+                0,
+                str(test_dir),
+                None,
+                None,
+                'asmtest',
+            )
+
+        self.assertEqual(configgen.model.isa_name, 'tester-assembly', 'name should be in ISA config')
+
+        configgen.generate()
+
+        extension_dirpath = os.path.join(str(test_dir), 'extensions')
+
+        package_fp = os.path.join(extension_dirpath, 'tester-assembly', 'package.json')
+        self.assertIsFile(package_fp)
+        with open(package_fp, 'r') as json_file:
+            package_json = json.load(json_file)
+        self.assertEqual(package_json['name'], 'tester-assembly', 'package name should be modified ISA name')
+        self.assertEqual(package_json['contributes']['languages'][0]['id'], 'tester-assembly-assembly', 'language ID should be modified ISA name')
+        self.assertEqual(package_json['contributes']['languages'][0]['extensions'], ['.asmtest'], 'file extension list should match')
+        self.assertEqual(package_json['contributes']['grammars'][0]['language'], 'tester-assembly-assembly', 'language ID should be modified ISA name')
+        self.assertEqual(package_json['contributes']['snippets'][0]['language'], 'tester-assembly-assembly', 'language ID should be modified ISA name')
+        self.assertEqual(package_json['contributes']['snippets'][0]['language'], 'tester-assembly-assembly', 'language ID should be modified ISA name')
+
+        grammar_fp = os.path.join(extension_dirpath, 'tester-assembly', 'syntaxes', 'tmGrammar.json')
+        self.assertIsFile(grammar_fp)
+        with open(grammar_fp, 'r') as json_file:
+            grammar_json = json.load(json_file)
+        instruction_str = grammar_json['repository']['instructions']['match']
+        instruction_match = re.search(r'\(\?\:(.*)\)', instruction_str, re.IGNORECASE)
+        self.assertIsNotNone(instruction_match, 'instruction match should be found')
+        instruction_list = set(instruction_match.group(1).split('|'))
+        self.assertSetEqual(instruction_list, set(['nop', 'mov']), 'all instructions should be found')
+        registers_str = grammar_json['repository']['registers']['match']
+        regsiters_match = re.search(r'\(\?\:(.*)\)', registers_str, re.IGNORECASE)
+        self.assertIsNotNone(regsiters_match, 'registers match should be found')
+        registers_list = set(regsiters_match.group(1).split('|'))
+        self.assertSetEqual(registers_list, set(['a', 'i', 'h', 'l', 'hl', 'sp', 'mar']), 'all registers should be found')
+
+        self.assertIsFile(os.path.join(extension_dirpath, 'tester-assembly', 'snippets.json'))
+        self.assertIsFile(os.path.join(extension_dirpath, 'tester-assembly', 'language-configuration.json'))
+
+        shutil.rmtree(test_dir)


### PR DESCRIPTION
Added the ability for BespokeASM to generate an language extension for Visual Studio Code that enables a few features for the assembly language a specific instruction set architecture configuration would produce. 