### PR TITLE
Listing Pretty Print Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changes that are planned but not implemented yet:
   * unknown labels
 
 ## [Unreleased]
+
+## [0.3.3]
 * Improved error messages for a badly configured configuration file.
 * Added the listing pretty print format, replacing the legacy default pretty print format.
 
@@ -118,7 +120,8 @@ First tracked released
 * Enabled the `reverse_argument_order` instruction option be applied to a specific operand configuration. This slightly changed the configuration file format.
 * Added ability for instructions with operands to have a single "empty operand" variant, e.g., `pop`
 
-[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/michaelkamprath/bespokeasm/compare/v0.2.4...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Changes that are planned but not implemented yet:
   * unknown labels
 
 ## [Unreleased]
+* Improved error messages for a badly configured configuration file.
+* Added the listing pretty print format, replacing the legacy default pretty print format.
 
 ## [0.3.2]
 * Corrected workflows bug

--- a/examples/intel-8085/intel-8085.yaml
+++ b/examples/intel-8085/intel-8085.yaml
@@ -319,7 +319,7 @@ instructions:
           - register_pairs
           - uint16_no_bytecode
   stax:
-    # store A direct to memory address in register pair
+    # store A contents direct to memory address in register pair
     # Bit format 00xx0010, xx = register pair BC or DE
     bytecode:
       value: 0

--- a/src/bespokeasm/__init__.py
+++ b/src/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = "0.3.2"
+BESPOKEASM_VERSION_STR = "0.3.3"
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = "0.3.0"

--- a/src/bespokeasm/__main__.py
+++ b/src/bespokeasm/__main__.py
@@ -50,8 +50,8 @@ def main():
     )
 @click.option(
         '--pretty-print-format', '-t',
-        type=click.Choice(['source_details', 'minhex', 'hex', 'intel_hex', 'listing'], case_sensitive=False),
-        default='source_details',
+        type=click.Choice(['minhex', 'hex', 'intel_hex', 'listing'], case_sensitive=False),
+        default='listing',
         help='The format that should be used when pretty printing.',
 )
 @click.option(

--- a/src/bespokeasm/__main__.py
+++ b/src/bespokeasm/__main__.py
@@ -19,7 +19,7 @@ def main():
 @click.argument('asm_file')
 @click.option('--config-file', '-c', required=True, help='The filepath to the instruction set configuration file,')
 @click.option(
-        '--generate-binary/--no-binary',
+        '--binary/--no-binary', '-b/-n',
         default=True,
         help='Indicates whether a binary image of the compiled bytecode should be generated.'
     )
@@ -50,7 +50,7 @@ def main():
     )
 @click.option(
         '--pretty-print-format', '-t',
-        type=click.Choice(['source_details', 'minhex', 'hex', 'intel_hex'], case_sensitive=False),
+        type=click.Choice(['source_details', 'minhex', 'hex', 'intel_hex', 'listing'], case_sensitive=False),
         default='source_details',
         help='The format that should be used when pretty printing.',
 )
@@ -66,7 +66,7 @@ def main():
 def compile(
             asm_file,
             config_file,
-            generate_binary,
+            binary,
             output_file,
             binary_min_address,
             binary_max_address,
@@ -81,7 +81,7 @@ def compile(
         output_file = os.path.splitext(asm_file)[0] + '.bin'
     if verbose:
         click.echo(f'The file to assemble is: {asm_file}')
-        if generate_binary:
+        if binary:
             click.echo(f'The binary image will be written to: {output_file}')
         if int(binary_min_address) > 0:
             click.echo(f'  with the starting address written: {binary_min_address}')
@@ -90,7 +90,7 @@ def compile(
 
     asm = Assembler(
         asm_file, config_file,
-        generate_binary, output_file,
+        binary, output_file,
         int(binary_min_address), int(binary_max_address) if int(binary_max_address) >= 0 else None,
         binary_fill,
         pretty_print, pretty_print_format, pretty_print_output, verbose,

--- a/src/bespokeasm/assembler/engine.py
+++ b/src/bespokeasm/assembler/engine.py
@@ -29,7 +29,7 @@ class Assembler:
                 is_verbose: int,
                 include_paths: list[str],
             ):
-        self.source_file = source_file
+        self._source_file = source_file
         self._output_file = output_file
         self._config_file = config_file
         self._generate_binary = generate_binary
@@ -73,9 +73,9 @@ class Assembler:
 
             # add its label to the global scope
         # find base file containing directory
-        include_dirs = set([os.path.dirname(self.source_file)]+list(self._include_paths))
+        include_dirs = set([os.path.dirname(self._source_file)]+list(self._include_paths))
 
-        asm_file = AssemblyFile(self.source_file, global_label_scope)
+        asm_file = AssemblyFile(self._source_file, global_label_scope)
         line_obs: list[LineObject] = asm_file.load_line_objects(
             self._model,
             include_dirs,
@@ -155,7 +155,12 @@ class Assembler:
             print('NOT writing byte code to binary image.')
 
         if self._enable_pretty_print:
-            pprinter = PrettyPrinterFactory.getPrettyPrinter(self._pretty_print_format, line_obs, self._model)
+            pprinter = PrettyPrinterFactory.getPrettyPrinter(
+                self._pretty_print_format,
+                line_obs,
+                self._model,
+                self._source_file,
+            )
             pretty_str = pprinter.pretty_print()
             if self._pretty_print_output == 'stdout':
                 print(pretty_str)

--- a/src/bespokeasm/assembler/engine.py
+++ b/src/bespokeasm/assembler/engine.py
@@ -111,7 +111,6 @@ class Assembler:
         # second pass: build the machine code and check for overlaps
         if self._verbose > 2:
             print("\nProcessing lines:")
-        max_instruction_text_size = 0
         bytecode = bytearray()
         last_line = None
         for lobj in line_obs:
@@ -119,8 +118,6 @@ class Assembler:
                 lobj.generate_bytes()
             if self._verbose > 2:
                 click.echo(f'Processing {lobj.line_id} = {lobj} at address ${lobj.address:x}')
-            if len(lobj.instruction) > max_instruction_text_size:
-                max_instruction_text_size = len(lobj.instruction)
             if isinstance(lobj, LineWithBytes):
                 if last_line is not None and (last_line.address + last_line.byte_size) > lobj.address:
                     sys.exit(
@@ -159,7 +156,7 @@ class Assembler:
 
         if self._enable_pretty_print:
             pprinter = PrettyPrinterFactory.getPrettyPrinter(self._pretty_print_format, line_obs, self._model)
-            pretty_str = pprinter.pretty_print(max_instruction_text_size)
+            pretty_str = pprinter.pretty_print()
             if self._pretty_print_output == 'stdout':
                 print(pretty_str)
             else:

--- a/src/bespokeasm/assembler/model/instruction.py
+++ b/src/bespokeasm/assembler/model/instruction.py
@@ -40,13 +40,16 @@ class InstructionVariant(InstructionBase):
                     f'byte code configuration in variant {variant_num}.'
                 )
         if 'operands' in self._variant_config:
-            self._operand_parser = OperandParser(
-                mnemonic,
-                self._variant_config.get('operands', None),
-                operand_set_collection,
-                default_endian,
-                registers,
-            )
+            try:
+                self._operand_parser = OperandParser(
+                    mnemonic,
+                    self._variant_config.get('operands', None),
+                    operand_set_collection,
+                    default_endian,
+                    registers,
+                )
+            except TypeError as e:
+                sys.exit(f'ERROR: Operand configuration for instruction "{mnemonic}" is invalid: {e}')
             self._operand_parser.validate(mnemonic)
         else:
             self._operand_parser = None

--- a/src/bespokeasm/assembler/pretty_printer/__init__.py
+++ b/src/bespokeasm/assembler/pretty_printer/__init__.py
@@ -1,4 +1,4 @@
-from bespokeasm.assembler.line_object import LineObject
+from bespokeasm.assembler.line_object import LineObject, LineWithBytes
 from bespokeasm.assembler.model import AssemblerModel
 
 
@@ -9,11 +9,15 @@ class PrettyPrinterBase:
         # scan though the line objects to get max widths
         line_num_max = 0
         instruction_max_width = 0
+        self._max_byte_count = 0
         for lo in line_objs:
             if lo.line_id.line_num > line_num_max:
                 line_num_max = lo.line_id.line_num
             if len(lo.instruction) > instruction_max_width:
                 instruction_max_width = len(lo.instruction)
+            if isinstance(lo, LineWithBytes):
+                if len(lo.get_bytes()) > self._max_byte_count:
+                    self._max_byte_count = len(lo.get_bytes())
         self._max_line_num_width = len(str(line_num_max))
         self._max_instruction_width = instruction_max_width
 
@@ -32,6 +36,10 @@ class PrettyPrinterBase:
     @property
     def max_instruction_width(self) -> int:
         return self._max_instruction_width
+
+    @property
+    def max_byte_count(self) -> int:
+        return self._max_byte_count
 
     def pretty_print(self) -> str:
         raise NotImplementedError

--- a/src/bespokeasm/assembler/pretty_printer/__init__.py
+++ b/src/bespokeasm/assembler/pretty_printer/__init__.py
@@ -6,6 +6,16 @@ class PrettyPrinterBase:
     def __init__(self, line_objs:  list[LineObject], model: AssemblerModel) -> None:
         self._line_objs = line_objs
         self._model = model
+        # scan though the line objects to get max widths
+        line_num_max = 0
+        instruction_max_width = 0
+        for lo in line_objs:
+            if lo.line_id.line_num > line_num_max:
+                line_num_max = lo.line_id.line_num
+            if len(lo.instruction) > instruction_max_width:
+                instruction_max_width = len(lo.instruction)
+        self._max_line_num_width = len(str(line_num_max))
+        self._max_instruction_width = instruction_max_width
 
     @property
     def line_objects(self) -> list[LineObject]:
@@ -15,5 +25,13 @@ class PrettyPrinterBase:
     def model(self) -> AssemblerModel:
         return self._model
 
-    def pretty_print(self, max_instruction_text_size: int) -> str:
+    @property
+    def max_line_num_width(self) -> int:
+        return self._max_line_num_width
+
+    @property
+    def max_instruction_width(self) -> int:
+        return self._max_instruction_width
+
+    def pretty_print(self) -> str:
         raise NotImplementedError

--- a/src/bespokeasm/assembler/pretty_printer/__init__.py
+++ b/src/bespokeasm/assembler/pretty_printer/__init__.py
@@ -3,18 +3,26 @@ from bespokeasm.assembler.model import AssemblerModel
 
 
 class PrettyPrinterBase:
-    def __init__(self, line_objs:  list[LineObject], model: AssemblerModel) -> None:
+    def __init__(
+                self,
+                line_objs: list[LineObject],
+                model: AssemblerModel,
+                instruction_indent: int = 0,
+            ) -> None:
         self._line_objs = line_objs
         self._model = model
         # scan though the line objects to get max widths
         line_num_max = 0
         instruction_max_width = 0
         self._max_byte_count = 0
+        self._max_comment_width = 0
         for lo in line_objs:
             if lo.line_id.line_num > line_num_max:
                 line_num_max = lo.line_id.line_num
-            if len(lo.instruction) > instruction_max_width:
-                instruction_max_width = len(lo.instruction)
+            if len(lo.instruction) + instruction_indent > instruction_max_width:
+                instruction_max_width = len(lo.instruction) + instruction_indent
+            if len(lo.comment) > self._max_comment_width:
+                self._max_comment_width = len(lo.comment)
             if isinstance(lo, LineWithBytes):
                 if len(lo.get_bytes()) > self._max_byte_count:
                     self._max_byte_count = len(lo.get_bytes())
@@ -31,7 +39,7 @@ class PrettyPrinterBase:
 
     @property
     def max_line_num_width(self) -> int:
-        return self._max_line_num_width
+        return max(self._max_line_num_width, 4)
 
     @property
     def max_instruction_width(self) -> int:
@@ -40,6 +48,10 @@ class PrettyPrinterBase:
     @property
     def max_byte_count(self) -> int:
         return self._max_byte_count
+
+    @property
+    def max_comment_width(self) -> int:
+        return self._max_comment_width
 
     def pretty_print(self) -> str:
         raise NotImplementedError

--- a/src/bespokeasm/assembler/pretty_printer/factory.py
+++ b/src/bespokeasm/assembler/pretty_printer/factory.py
@@ -2,6 +2,7 @@ from bespokeasm.assembler.pretty_printer import PrettyPrinterBase
 from bespokeasm.assembler.pretty_printer.source_details import SourceDetailsPrettyPrinter
 from bespokeasm.assembler.pretty_printer.minhex import MinHexPrettyPrinter
 from bespokeasm.assembler.pretty_printer.intelhex import IntelHexPrettyPrinter
+from bespokeasm.assembler.pretty_printer.listing import ListingPrettyPrinter
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.model import AssemblerModel
 
@@ -23,4 +24,6 @@ class PrettyPrinterFactory:
             return IntelHexPrettyPrinter(line_objs, model, False)
         elif pretty_printer_type == 'intel_hex':
             return IntelHexPrettyPrinter(line_objs, model, True)
+        elif pretty_printer_type == 'listing':
+            return ListingPrettyPrinter(line_objs, model)
         raise NotImplementedError

--- a/src/bespokeasm/assembler/pretty_printer/factory.py
+++ b/src/bespokeasm/assembler/pretty_printer/factory.py
@@ -14,7 +14,8 @@ class PrettyPrinterFactory:
             cls,
             pretty_printer_type: str,
             line_objs:  list[LineObject],
-            model: AssemblerModel
+            model: AssemblerModel,
+            main_filename: str,
     ) -> PrettyPrinterBase:
         if pretty_printer_type == 'source_details':
             return SourceDetailsPrettyPrinter(line_objs, model)
@@ -25,5 +26,5 @@ class PrettyPrinterFactory:
         elif pretty_printer_type == 'intel_hex':
             return IntelHexPrettyPrinter(line_objs, model, True)
         elif pretty_printer_type == 'listing':
-            return ListingPrettyPrinter(line_objs, model)
+            return ListingPrettyPrinter(line_objs, model, main_filename)
         raise NotImplementedError

--- a/src/bespokeasm/assembler/pretty_printer/intelhex.py
+++ b/src/bespokeasm/assembler/pretty_printer/intelhex.py
@@ -14,7 +14,7 @@ class IntelHexPrettyPrinter(PrettyPrinterBase):
         self._intel_hex = IntelHex()
         self._as_intel_hex = as_intel_hex
 
-    def pretty_print(self, max_instruction_text_size: int) -> str:
+    def pretty_print(self) -> str:
         output = io.StringIO()
         for lobj in self.line_objects:
             if isinstance(lobj, LineWithBytes):

--- a/src/bespokeasm/assembler/pretty_printer/listing.py
+++ b/src/bespokeasm/assembler/pretty_printer/listing.py
@@ -1,0 +1,49 @@
+import io
+import math
+
+from bespokeasm.assembler.line_object import LineObject
+from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.assembler.pretty_printer import PrettyPrinterBase
+from bespokeasm.assembler.line_identifier import LineIdentifier
+
+
+class ListingPrettyPrinter(PrettyPrinterBase):
+    """
+    line number | address | machine code (6 bytes wide) | instruction | comment
+    """
+    def __init__(self, line_objs:  list[LineObject], model: AssemblerModel, main_filename: str) -> None:
+        super().__init__(line_objs, model)
+        self._address_size = math.ceil(self.model.address_size/4)
+        self._address_format_str = f'{{0:0{self._address_size}x}}'
+        self._main_filename = main_filename
+
+    def pretty_print(self) -> str:
+        if len(self.line_objects) < 1:
+            return ''
+
+        output = io.StringIO()
+
+        # create a new list of line objects sorted by file then line number.
+        lobjs: list[LineIdentifier] = self.line_objects.copy()
+        lobjs.sort(
+            key=lambda x: str(x.line_id) if x.filename == self._main_filename else f'z_{x.filename}_{x.line_id}'
+        )
+
+        cur_filename = None
+        for lo in lobjs:
+            # detect a new file
+            if lo.filename != cur_filename:
+                # print new file header
+                cur_filename = lo.filename
+                self._print_file_header(output, cur_filename)
+
+            self._print_line_object(output, lo)
+        return output.getvalue()
+
+    def _print_file_header(self, output: io.StringIO, filename: str) -> None:
+        output.write('********************\n\n')
+        output.write(f'File: {filename}\n')
+        output.write('---\n')
+
+    def _print_line_object(self, output: io.StringIO, lobj: LineObject) -> None:
+        raise NotImplementedError

--- a/src/bespokeasm/assembler/pretty_printer/listing.py
+++ b/src/bespokeasm/assembler/pretty_printer/listing.py
@@ -1,7 +1,7 @@
 import io
 import math
 
-from bespokeasm.assembler.line_object import LineObject
+from bespokeasm.assembler.line_object import LineObject, LineWithBytes
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.pretty_printer import PrettyPrinterBase
 from bespokeasm.assembler.line_identifier import LineIdentifier
@@ -16,6 +16,7 @@ class ListingPrettyPrinter(PrettyPrinterBase):
         self._address_size = math.ceil(self.model.address_size/4)
         self._address_format_str = f'{{0:0{self._address_size}x}}'
         self._main_filename = main_filename
+        self._bytes_per_line = min(6, self.max_byte_count)
 
     def pretty_print(self) -> str:
         if len(self.line_objects) < 1:
@@ -26,24 +27,103 @@ class ListingPrettyPrinter(PrettyPrinterBase):
         # create a new list of line objects sorted by file then line number.
         lobjs: list[LineIdentifier] = self.line_objects.copy()
         lobjs.sort(
-            key=lambda x: str(x.line_id) if x.filename == self._main_filename else f'z_{x.filename}_{x.line_id}'
+            key=lambda x:
+                f'{x.line_id.line_num:04d}'
+                if x.line_id.filename == self._main_filename
+                else f'z_{x.line_id.filename}_{x.line_id.line_num:04d}'
         )
 
         cur_filename = None
         for lo in lobjs:
             # detect a new file
-            if lo.filename != cur_filename:
+            if lo.line_id.filename != cur_filename:
                 # print new file header
-                cur_filename = lo.filename
+                cur_filename = lo.line_id.filename
                 self._print_file_header(output, cur_filename)
 
             self._print_line_object(output, lo)
         return output.getvalue()
 
     def _print_file_header(self, output: io.StringIO, filename: str) -> None:
-        output.write('********************\n\n')
+        output.write('\n********************\n\n')
         output.write(f'File: {filename}\n')
         output.write('---\n')
 
     def _print_line_object(self, output: io.StringIO, lobj: LineObject) -> None:
-        raise NotImplementedError
+        # wite the lobj details to output using the following format:
+        #    line number in decimal | address in hex | machine code in hex (6 bytes wide) | instruction text | comment text
+        #     1 | 0000 | 00 00 00 00 00 00 | nop | this is a comment
+        #
+        # If the lobj is not of type LineWithBytes, then the machine code field is left blank.
+        # If the lobj is of type LineWithBytes, then the machine code is shown as a series of bytes separated by spaces.
+        # If the machine code is less than 6 bytes, then only those bytes are shown with the remaining being whitespace. If
+        # the machine code is more than 6 bytes, then the extra bytes are shown on the next line with the other fields in
+        # the line being whitespace.
+        # The instruction text is left justified and padded with whitespace to the max_instruction_width.
+        # The comment text is left justified.
+        #
+
+        # first, get the line bytes, if any
+        line_bytes = None if not isinstance(lobj, LineWithBytes) else self._generate_bytecode_line_string(lobj.get_bytes())
+
+        # write the line number
+        output.write(f'{lobj.line_id.line_num:4d} | ')
+
+        # write the address
+        if lobj.address is not None:
+            output.write(self._address_format_str.format(lobj.address))
+        else:
+            output.write(' ' * (self._address_size))
+        output.write(' | ')
+
+        # write the machine code
+        if line_bytes is not None:
+            output.write(line_bytes[0])
+        else:
+            output.write(' ' * self._bytes_per_line * 3)
+        output.write('| ')
+
+        # write the instruction
+        output.write(f'{lobj.instruction: <{self.max_instruction_width}} | ')
+
+        # write the comment
+        output.write(lobj.comment)
+        output.write('\n')
+
+        if line_bytes is not None and len(line_bytes) > 1:
+            for bytes in line_bytes[1:]:
+                output.write(
+                    ' '*4 + ' | ' + ' '*self._address_size + ' | ' + bytes
+                    + '| ' + ' '*self.max_instruction_width + ' | \n'
+                )
+
+    def _generate_bytecode_line_string(self, line_bytes: bytearray) -> list[str]:
+        # conver the line_bytes to a list of strings, each string being a hex representation of a byte.
+        # Each line should contain at most 6 bytes. There should be as many strings in the return list
+        # as needed for each string to contain up to 6 bytes of line_bytes. The first byt through 6th byte
+        # in line_bytes gets added to the first string in the list, the 7th through 12th bytes get added
+        # to the second string in the list, etc. If the number of bytes in line_bytes is not a multiple of
+        # 6, then the last string in the list will be padded with whitespace to make it 6 bytes wide.
+        #
+        # Example:
+        #   line_bytes = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'
+        #   return = ['00 01 02 03 04 05', '06 07 08 09 0a 0b', '0c 0d 0e 0f    ']
+        #
+        #   line_bytes = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e'
+        #   return = ['00 01 02 03 04 05', '06 07 08 09 0a 0b', '0c 0d 0e       ']
+        #
+        #   line_bytes = b'\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d'
+        #   return = ['00 01 02 03 04 05', '06 07 08 09 0a 0b', '0c 0d          ']
+        #
+        results: list[str] = []
+        cur_str = None
+        for b in line_bytes:
+            if cur_str is None:
+                cur_str = ''
+            cur_str += f'{b:02x} '
+            if len(cur_str) == self._bytes_per_line*3:
+                results.append(cur_str)
+                cur_str = None
+        if cur_str is not None:
+            results.append(f'{cur_str:<{self._bytes_per_line*3}}')
+        return results

--- a/src/bespokeasm/assembler/pretty_printer/minhex.py
+++ b/src/bespokeasm/assembler/pretty_printer/minhex.py
@@ -10,7 +10,7 @@ class MinHexPrettyPrinter(PrettyPrinterBase):
     def __init__(self, line_objs:  list[LineObject], model: AssemblerModel) -> None:
         super().__init__(line_objs, model)
 
-    def pretty_print(self, max_instruction_text_size: int) -> str:
+    def pretty_print(self) -> str:
         output = io.StringIO()
         line_byte_count = 0
         address_width = int(self.model.address_size/4)

--- a/src/bespokeasm/assembler/pretty_printer/source_details.py
+++ b/src/bespokeasm/assembler/pretty_printer/source_details.py
@@ -11,7 +11,7 @@ class SourceDetailsPrettyPrinter(PrettyPrinterBase):
     def __init__(self, line_objs:  list[LineObject], model: AssemblerModel) -> None:
         super().__init__(line_objs, model)
 
-    def pretty_print(self, max_instruction_text_size: int) -> str:
+    def pretty_print(self) -> str:
         output = io.StringIO()
 
         address_size = math.ceil(self.model.address_size/4)
@@ -21,23 +21,22 @@ class SourceDetailsPrettyPrinter(PrettyPrinterBase):
         COL_WIDTH_BYTE = 4
         COL_WIDTH_BINARY = 8
         INSTRUCTION_INDENT = 4
-        max_instruction_text_size = max_instruction_text_size + INSTRUCTION_INDENT
         blank_line_num = ''.join([' '*COL_WIDTH_LINE])
-        blank_instruction_text = ''.join([' '*max_instruction_text_size])
+        blank_instruction_text = ''.join([' '*(self.max_instruction_width + INSTRUCTION_INDENT)])
         blank_address_text = ''.join([' '*COL_WIDTH_ADDRESS])
         blank_byte_text = ''.join([' '*COL_WIDTH_BYTE])
         blank_binary_text = ''.join([' '*COL_WIDTH_BINARY])
 
         header_text = ' {0} | {1} | {2} | {3} | {4} | Comment '.format(
             'Line'.center(COL_WIDTH_LINE),
-            'Code'.ljust(max_instruction_text_size),
+            'Code'.ljust(self.max_instruction_width + INSTRUCTION_INDENT),
             'Address'.center(COL_WIDTH_ADDRESS),
             'Byte'.center(COL_WIDTH_BYTE),
             'Binary'.center(COL_WIDTH_BINARY),
         )
         header_line_text = '-{0}-+-{1}-+-{2}-+-{3}-+-{4}-+---------------'.format(
             ''.join('-'*(COL_WIDTH_LINE)),
-            ''.join('-'*(max_instruction_text_size)),
+            ''.join('-'*(self.max_instruction_width)),
             ''.join('-'*(COL_WIDTH_ADDRESS)),
             ''.join('-'*(COL_WIDTH_BYTE)),
             ''.join('-'*(COL_WIDTH_BINARY)),
@@ -50,7 +49,7 @@ class SourceDetailsPrettyPrinter(PrettyPrinterBase):
             instruction_str = lobj.instruction
             if not isinstance(lobj, LabelLine):
                 instruction_str = ' '*INSTRUCTION_INDENT + instruction_str
-            instruction_str = instruction_str.ljust(max_instruction_text_size)
+            instruction_str = instruction_str.ljust(self.max_instruction_width + INSTRUCTION_INDENT)
 
             if isinstance(lobj, LineWithBytes):
                 line_bytes = lobj.get_bytes()


### PR DESCRIPTION
Changed the default pretty print format to be more inline with traditional assembler listing files. 

Also improved some error messages.

closes #10 