### PR TITLE
added support for character ordinals in numeric expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Changes that are planned but not implemented yet:
 
 ## [Unreleased]
 * Added the ability to set the `cstr` terminating character. It default to `0`, but can be set to another byte value.
+* Added support for using characeter ordinals in numeric expressions. For example, `'a'` is the same as `97`. Only valid for single character strings using single quotes.
 
 ## [0.3.3]
 * Improved error messages for a badly configured configuration file.

--- a/src/bespokeasm/expression/__init__.py
+++ b/src/bespokeasm/expression/__init__.py
@@ -18,7 +18,7 @@ from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.utilities import is_valid_label
 
 EXPRESSION_PARTS_PATTERN = \
-    r'(?:(?:\%|b)[01]+|{0}|\d+|[\+\-\*\/\&\|\^\(\)]|>>|<<|%|LSB\(|BYTE\d\(|(?:\.|_)?\w+)'.format(
+    r'(?:(?:\%|b)[01]+|{0}|\d+|[\+\-\*\/\&\|\^\(\)]|>>|<<|%|LSB\(|BYTE\d\(|(?:\.|_)?\w+|\'.\')'.format(
         PATTERN_HEX
     )
 

--- a/src/bespokeasm/utilities.py
+++ b/src/bespokeasm/utilities.py
@@ -1,6 +1,12 @@
 import re
 
 
+PATTERN_HEX = r'(?:\$|0x)[0-9a-fA-F]+|[0-9a-fA-F]+H\b'
+PATTERN_NUMERIC = r'(?:{0}|(?:b|%)[01]+|\d+|\'.\')'.format(PATTERN_HEX)
+PATTERN_NUMERIC_COMPILED = re.compile(f'^({PATTERN_NUMERIC})$', flags=re.IGNORECASE | re.MULTILINE)
+PATTERN_CHARACTER_ORDINAL = re.compile(r'\'(.)\'', flags=re.IGNORECASE | re.MULTILINE)
+
+
 def parse_numeric_string(numeric_str: str) -> int:
     """returns an integer value for the passed numeric string. Supports decimal,
     hexadecimal, and binary numbers. Throws `ValueError` for strings that are not
@@ -14,13 +20,13 @@ def parse_numeric_string(numeric_str: str) -> int:
         return int(numeric_str[:-1], 16)
     elif numeric_str.startswith('b') or numeric_str.startswith('%'):
         return int(numeric_str[1:], 2)
+    elif numeric_str.startswith('\'') or numeric_str.startswith('"'):
+        match = re.match(PATTERN_CHARACTER_ORDINAL, numeric_str)
+        if match is None:
+            raise ValueError(f'Invalid character literal: {numeric_str}')
+        return ord(match.group(1))
     else:
         return int(numeric_str)
-
-
-PATTERN_HEX = r'(?:\$|0x)[0-9a-fA-F]+|[0-9a-fA-F]+H\b'
-PATTERN_NUMERIC = r'(?:{0}|(?:b|%)[01]+|\d+)'.format(PATTERN_HEX)
-PATTERN_NUMERIC_COMPILED = re.compile(f'^({PATTERN_NUMERIC})$', flags=re.IGNORECASE | re.MULTILINE)
 
 
 def is_string_numeric(value_str: str) -> bool:

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -190,6 +190,25 @@ class TestExpression(unittest.TestCase):
             2, 'BYTE2( MAX_N*MAX_N*MAX_N*MAX_N ) = BYTE2( 0x027100 ) = 2'
         )
 
+    def test_character_ordinals_in_expressions(self):
+        line_id = LineIdentifier(888, 'test_character_ordinals_in_expressions')
+        self.assertEqual(
+            parse_expression(line_id, "'a'").get_value(TestExpression.label_values, 1),
+            97, "'a' = 97"
+        )
+        self.assertEqual(
+            parse_expression(line_id, "'A' + 32").get_value(TestExpression.label_values, 1),
+            97, "'A' + 32 = 97"
+        )
+        self.assertEqual(
+            parse_expression(line_id, "(' '*32)").get_value(TestExpression.label_values, 1),
+            1024, "(' '*32) = 1024"
+        )
+        self.assertEqual(
+            parse_expression(line_id, "(' ' + ' ')").get_value(TestExpression.label_values, 1),
+            64, "(' ' + ' ') = 64"
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_utilities.py
+++ b/test/test_utilities.py
@@ -12,6 +12,9 @@ class TestUtilities(unittest.TestCase):
         self.assertEqual(parse_numeric_string('b0000010011010010'), 1234, 'binary integer test: 1234')
         self.assertEqual(parse_numeric_string('-1212'), -1212, 'signed interger: -1212')
         self.assertEqual(parse_numeric_string('%10011001'), 0x99, 'binary interger: 0x99')
+        self.assertEqual(parse_numeric_string("'1'"), 49, 'character ordinal: \'1\' = 49')
+        self.assertEqual(parse_numeric_string('b10011001'), 0x99, 'binary interger: 0x99')
+        self.assertEqual(parse_numeric_string("' '"), 32, 'character ordinal: \' \' = 32')
 
         with self.assertRaises(ValueError, msg='only integer numeric values are supported'):
             parse_numeric_string('nan')
@@ -30,6 +33,9 @@ class TestUtilities(unittest.TestCase):
         self.assertFalse(is_string_numeric('b'), 'the prefix b alone is not numeric')
         self.assertFalse(is_string_numeric('$'), 'the prefix alon is not numeric')
         self.assertTrue(is_string_numeric('08FH'), 'string is numeric (hexadecimal)')
+        self.assertTrue(is_string_numeric("'1'"), 'string is numeric (character ordinal)')
+        self.assertFalse(is_string_numeric("'12'"), 'character ordinal can only be one character long')
+        self.assertFalse(is_string_numeric("0b10011001"), 'binary numbers do not strt with "0b"')
 
     def test_PackedBits(self):
         ib1 = PackedBits()


### PR DESCRIPTION
Can now use single quoted characters as there ASCII ordinal value in numeric expressions.