### PR TITLE
Preprocessor Symbols and Compilation Control

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,7 @@
 {
-    "python.testing.unittestArgs": [
-        "-v",
-        "-s",
-        "./test",
-        "-p",
-        "test_*.py"
+    "python.unitTest.pyTestArgs": [
     ],
-    "python.testing.pytestEnabled": false,
+    "python.testing.pytestEnabled": true,
     "python.testing.nosetestsEnabled": false,
-    "python.testing.unittestEnabled": true
+    "python.testing.unittestEnabled": false
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ Changes that are planned but not implemented yet:
   * unknown labels
 
 ## [Unreleased]
+* Added conditional assembly preprocessor directives:
+  * `#define`
+  * `#if`
+  * `#elif`
+  * `#else`
+  * `#endif`
+  * `#ifdef`
+  * `#ifndef`
+  Also added the ability to define proporcessor symbols on the command line and in the instruction set configuration file.
 * Added the ability to set the `cstr` terminating character. It default to `0`, but can be set to another byte value.
 * Added support for using characeter ordinals in numeric expressions. For example, `'a'` is the same as `97`. Only valid for single character strings using single quotes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Changes that are planned but not implemented yet:
   * `#endif`
   * `#ifdef`
   * `#ifndef`
-  Also added the ability to define proporcessor symbols on the command line and in the instruction set configuration file.
+  Also added the ability to define preprocessor symbols on the command line and in the instruction set configuration file.
 * Added the ability to set the `cstr` terminating character. It default to `0`, but can be set to another byte value.
 * Added support for using characeter ordinals in numeric expressions. For example, `'a'` is the same as `97`. Only valid for single character strings using single quotes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,17 +15,19 @@ Changes that are planned but not implemented yet:
   * unknown labels
 
 ## [Unreleased]
-* Added conditional assembly preprocessor directives:
-  * `#define`
+
+## [0.4.0]
+* Added ability to create preprocessor macros/symbols with `#define` directive. Thes macros can then be used in code. Also added the ability to define preprocessor symbols on the command line and in the instruction set configuration file.
+* Added conditional assembly preprocessor directives tht act on preprocessor symbols:
   * `#if`
   * `#elif`
   * `#else`
   * `#endif`
   * `#ifdef`
   * `#ifndef`
-  Also added the ability to define preprocessor symbols on the command line and in the instruction set configuration file.
 * Added the ability to set the `cstr` terminating character. It default to `0`, but can be set to another byte value.
-* Added support for using characeter ordinals in numeric expressions. For example, `'a'` is the same as `97`. Only valid for single character strings using single quotes.
+* Added support for using character ordinals in numeric expressions. For example, `'a'` is the same as `97`. Only valid for single character strings using single quotes.
+* Allow expressions to be used in data directives. For example, `.byte 1 + 2` is the same as `.byte 3`.
 
 ## [0.3.3]
 * Improved error messages for a badly configured configuration file.
@@ -131,7 +133,8 @@ First tracked released
 * Enabled the `reverse_argument_order` instruction option be applied to a specific operand configuration. This slightly changed the configuration file format.
 * Added ability for instructions with operands to have a single "empty operand" variant, e.g., `pop`
 
-[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.3...HEAD
+[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/michaelkamprath/bespokeasm/compare/v0.3.0...v0.3.1

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Bespoke ASM
 This is a customizable byte code assembler that allows for the definition of custom instruction set architecture.
 
-**NOTE - This is very much a work in progress**
+**NOTE - This project should be considered to be in "beta" status. It should be stable, but features are subject to change.**
 
 ## Usage
 To install, clone this repository and install using `pip`. Preferably, you have a `python` virtual environment set up and it has `pipenv` installed when you do this.

--- a/docs/compilation-control-requirements.md
+++ b/docs/compilation-control-requirements.md
@@ -6,8 +6,8 @@
 `#define <symbol-name> <replacement-value>`
 
 * A symbol has two attributes: the fact it has been defined and what its replacement value is.
-* A symbol name is case sensitive, alphanumeric plus `_`, and must not have spaces in it
-* The replacement value is all text after the first white space after the symbol name up to either the end of line or a comment start symbol (`;`), which ever comes first. This text will get trimmed of bounding whitespace. The reaplement value may be a zero-length string.
+* A symbol name is case sensitive, alphanumeric plus `_`, and must not have spaces in it. The first character must be a letter or `_`.
+* The replacement value is all text after the first white space after the symbol name up to either the end of line or a comment start symbol (`;`), which ever comes first. This text will get trimmed of bounding whitespace. The replacement value may be a zero-length string.
 * The replacement value will be lazily evaluated.
 * A symbol is in the global scope at the moment it gets defined (when it's line of code is processed) and may be used from that point forward.
 * When a defined symbol is present in a line of note (not any preprocessor directive), before that line of code is compiled the symbol with be replaced with its replacement value string.
@@ -48,7 +48,7 @@ When a `#ifdef` directive is encountered, the symbol will be checked for a defin
 * If the boolean comparison is true, the lines of code between the `#if` and `#else` directives will be compiled, and the lines of code between the `#else` and `#endif` directives will not be compiled. If the boolean comparison is false, the lines of code between the `#else` and `#endif` directives will be compiled, and the lines of code between the `#if` and `#else` directives will not be compiled. Tf there is no `#else` directive, the lines of code between the `#if` and `#endif` directives will be compiled if the comparison is true.
 * The `#if` directive may be followed by an `#else` directive, which will be followed by a `#endif` directive. The `#else` directive is optional.
 * `#if` directives may be nested. The outer most `#if` directive will be evaluated first, and the inner most `#if` directive will be evaluated last. If an `#if` block is contained within another `#if` block, the inner `#if` block will be evaluated if the outer `#if` block is compiled. If the outer `#if` block is not compiled, the inner `#if` block will not be evaluted.
-* The `#if` directive may be followed by an `#elif` directive, which will be followed by another `#elif`, an `#else`, or an `#endif` directive. The `#elif` directive is shorthand for embedded another `#if` directive in the current `#if` block. The `#elif` directive is optional. In an `#if` / `#elif` / `#else` / `#endif` block, there can be only one `#if` at the start, and only zero or one `#else` at the end. There can be zero or more `#elif` directives in between the `#if` and `#else` directives. In an `#if` / `#elif` / `#else` / `#endif` block, only one of the `#if`, `#elif`, and `#else` directives will be compiled.
+* The `#if` directive may be followed by one or more `#elif` directives, which will be followed by an `#else` or an `#endif` directive. The `#elif` directive is shorthand for embedded another `#if` directive in the current `#if` block. The `#elif` directive is optional. In an `#if` / `#elif` / `#else` / `#endif` block, there can be only one `#if` at the start, and only zero or one `#else` at the end prior to the `#endif`. There can be zero or more `#elif` directives in between the `#if` and `#else` directives. In an `#if` / `#elif` / `#else` / `#endif` block, only one of the `#if`, `#elif`, and `#else` directives will be compiled, which is the first one that evaluates to true.
 
 ## In-code Symbol Replacement
 

--- a/docs/compilation-control-requirements.md
+++ b/docs/compilation-control-requirements.md
@@ -1,0 +1,36 @@
+# Compilation Control
+
+
+## Symbol Definition
+
+### In-Code Symbol Definition
+`#define <symbol-name> <replacement-value>`
+
+* A symbol has two attributes: the fact it has been defined and what its replacement value is.
+* A symbol name is case sensitive, alphanumeric plus `_`, and must not have spaces in it
+
+### Predefined Symbols
+
+### Compile Command Symbol Definition
+
+## Compilation Control Blocks
+
+
+### Symbol Status Bolean
+`#ifdef <symbol-name>`
+
+### Symbol Replacement Value Comparison
+`#if <symbol-name> <comparison-operator> <comparison-value>`
+
+* If both the symbol replacement value and the comparison value can be converted to an integer, they will be and the comparison will be made based on interger values.
+* If a symbol is undefined at the time of evaluation, the boolean comparison will alwys evaluate to `false`.
+
+### Else Case
+`#else`
+
+### Block Termination
+`#endif`
+
+## In-code Symbol Replacement
+
+* If a symbol is undefined at the time a line of code is being evaluated, an error will be generated indicating an undefined symbol in code.

--- a/docs/compilation-control-requirements.md
+++ b/docs/compilation-control-requirements.md
@@ -7,7 +7,7 @@
 
 * A symbol has two attributes: the fact it has been defined and what its replacement value is.
 * A symbol name is case sensitive, alphanumeric plus `_`, and must not have spaces in it
-* The replacement value is all text after the first white space after the symbol name up to either the end of line or a comment start symbol (`;`), which ever comes first. This text will get trimmed of bounding whitespace.
+* The replacement value is all text after the first white space after the symbol name up to either the end of line or a comment start symbol (`;`), which ever comes first. This text will get trimmed of bounding whitespace. The reaplement value may be a zero-length string.
 * The replacement value will be lazily evaluated.
 * A symbol is in the global scope at the moment it gets defined (when it's line of code is processed) and may be used from that point forward.
 * When a defined symbol is present in a line of note (not any preprocessor directive), before that line of code is compiled the symbol with be replaced with its replacement value string.

--- a/docs/compilation-control-requirements.md
+++ b/docs/compilation-control-requirements.md
@@ -34,10 +34,10 @@ When a `#ifdef` directive is encountered, the symbol will be checked for a defin
 ### Symbol Value Comparison
 `#if <symbol-expression> [<comparison-operator> <symbol-expression>]`
 
-* A symbol expression is any combination of preprocessor symbols, label or constant values, numeric values, and mathemtical operators.
+* A symbol expression is any combination of preprocessor symbols, numeric values, and mathemtical operators.
 * The comparison operator and right side symbol expression is optional. If not present, the comparison operator and right side symbol expression is assumed to be `!= 0`
 * If both symbol expressions value and the comparison value can be converted to an integer, they will be and the comparison will be made based on theirinterger values.
-* If a symbol used in the symbol expression is undefined at the time of evaluation, the boolean comparison will always evaluate to `false`. If a label or constant used in the symbol expression is undefined at the time of evaluation, an error will be generated.
+* If a symbol used in the symbol expression is undefined at the time of evaluation, the boolean comparison will always evaluate to `false`. If a label or constant used in the symbol expression, an error will be generated.
 * The comparison operator may be one of the following:
   * `==` - equal to
   * `!=` - not equal to

--- a/docs/compilation-control-requirements.md
+++ b/docs/compilation-control-requirements.md
@@ -52,5 +52,8 @@ When a `#ifdef` directive is encountered, the symbol will be checked for a defin
 
 ## In-code Symbol Replacement
 
-* If a symbol is used in the code, it will be replaced with its replacement value string before the line of code is compiled.
-* If a symbol is undefined at the time a line of code is being evaluated, an error will be generated indicating an undefined symbol in code.
+* If a symbol is used in the code, it will be replaced with its replacement value string when the line is first read and evaluated. The replacement value string will be lazily evaluated.
+  * This only applies to non-preprocessor lines. Preprocessor lines will be evaluated when the preprocessor directive is encountered. Generally, preprocessor symbols are only resolved in compilation control processor directives.
+* Preprocessor symbols can be used to define lanel names. However, the resolved symbol value muist be a valid label name.
+* If a symbol is not defined when a line of code is read, it does not get replaced with its replacement value string even if the symbol is defined later in the code.
+* If a symbol is undefined at the time a compilation control preprocessor directive is being evaluated, an error will be generated indicating an undefined symbol in code.

--- a/docs/compilation-control-requirements.md
+++ b/docs/compilation-control-requirements.md
@@ -1,6 +1,5 @@
 # Compilation Control
 
-
 ## Symbol Definition
 
 ### In-Code Symbol Definition
@@ -8,29 +7,50 @@
 
 * A symbol has two attributes: the fact it has been defined and what its replacement value is.
 * A symbol name is case sensitive, alphanumeric plus `_`, and must not have spaces in it
+* The replacement value is all text after the first white space after the symbol name up to either the end of line or a comment start symbol (`;`), which ever comes first. This text will get trimmed of bounding whitespace.
+* The replacement value will be lazily evaluated.
+* A symbol is in the global scope at the moment it gets defined (when it's line of code is processed) and may be used from that point forward.
+* When a defined symbol is present in a line of note (not any preprocessor directive), before that line of code is compiled the symbol with be replaced with its replacement value string.
 
 ### Predefined Symbols
+Symbols can be predefined in the instruction set configuration YAML file in the `predefined` section. It will be a list of dictionaires under the `symbols` key, and each listry entry will name at a minimum a `name` key with a value of the symbol name. An optional `value` key will have a value of the replacement value for the symbol. If `value` is not present, the replacement value will be a zero-length string.
+
+All predefined symbols will be defined when code compilation starts.
 
 ### Compile Command Symbol Definition
+The BespokeASM command line `compile` compand with be able to take zero or more of the `-D` option to define symbols at compile time. The value of this option may be either `<symbol-name>` or `<symbol-name>=<reaplcement-value>`.
+
+### Multiple Symbol Definitions
+A symbol may only be defined once. If a symbol is defined more than once, an error will be generated.
 
 ## Compilation Control Blocks
-
+Contiguous lines of code may be conditionally compiled based on the value of a symbol. The symbol may be defined in the code, in the instruction set configuration YAML file, or on the command line. The symbol may be used in a comparison with another symbol or a numeric value. The contiguous lines of code are bounded by a `#if` and `#endif` directive. The `#if` directive may be followed by an `#else` directive, which will be followed by a `#endif` directive. The `#else` directive is optional. The lines of code between the `#if` and `#else` directives will be compiled if the boolean comparison is true. The lines of code between the `#else` and `#endif` directives will be compiled if the boolean comparison is false. If there is no `#else` directive, the lines of code between the `#if` and `#endif` directives will be compiled if the boolean comparison is true. The `#ifdef` and `#ifndef` directives are an alternative to the `#if` directive that will only compile the lines of code if the symbol is defined.
 
 ### Symbol Status Bolean
 `#ifdef <symbol-name>`
 
-### Symbol Replacement Value Comparison
-`#if <symbol-name> <comparison-operator> <comparison-value>`
+When a `#ifdef` directive is encountered, the symbol will be checked for a defined status. If the symbol is defined, the lines of code between the `#ifdef` and `#endif` directives will be compiled. If the symbol is not defined, the lines of code between the `#ifdef` and `#endif` directives will not be compiled.
 
-* If both the symbol replacement value and the comparison value can be converted to an integer, they will be and the comparison will be made based on interger values.
-* If a symbol is undefined at the time of evaluation, the boolean comparison will alwys evaluate to `false`.
+### Symbol Value Comparison
+`#if <symbol-expression> [<comparison-operator> <symbol-expression>]`
 
-### Else Case
-`#else`
-
-### Block Termination
-`#endif`
+* A symbol expression is any combination of preprocessor symbols, label or constant values, numeric values, and mathemtical operators.
+* The comparison operator and right side symbol expression is optional. If not present, the comparison operator and right side symbol expression is assumed to be `!= 0`
+* If both symbol expressions value and the comparison value can be converted to an integer, they will be and the comparison will be made based on theirinterger values.
+* If a symbol used in the symbol expression is undefined at the time of evaluation, the boolean comparison will always evaluate to `false`. If a label or constant used in the symbol expression is undefined at the time of evaluation, an error will be generated.
+* The comparison operator may be one of the following:
+  * `==` - equal to
+  * `!=` - not equal to
+  * `>` - greater than
+  * `<` - less than
+  * `>=` - greater than or equal to
+  * `<=` - less than or equal to
+* If the boolean comparison is true, the lines of code between the `#if` and `#else` directives will be compiled, and the lines of code between the `#else` and `#endif` directives will not be compiled. If the boolean comparison is false, the lines of code between the `#else` and `#endif` directives will be compiled, and the lines of code between the `#if` and `#else` directives will not be compiled. Tf there is no `#else` directive, the lines of code between the `#if` and `#endif` directives will be compiled if the comparison is true.
+* The `#if` directive may be followed by an `#else` directive, which will be followed by a `#endif` directive. The `#else` directive is optional.
+* `#if` directives may be nested. The outer most `#if` directive will be evaluated first, and the inner most `#if` directive will be evaluated last. If an `#if` block is contained within another `#if` block, the inner `#if` block will be evaluated if the outer `#if` block is compiled. If the outer `#if` block is not compiled, the inner `#if` block will not be evaluted.
+* The `#if` directive may be followed by an `#elif` directive, which will be followed by another `#elif`, an `#else`, or an `#endif` directive. The `#elif` directive is shorthand for embedded another `#if` directive in the current `#if` block. The `#elif` directive is optional. In an `#if` / `#elif` / `#else` / `#endif` block, there can be only one `#if` at the start, and only zero or one `#else` at the end. There can be zero or more `#elif` directives in between the `#if` and `#else` directives. In an `#if` / `#elif` / `#else` / `#endif` block, only one of the `#if`, `#elif`, and `#else` directives will be compiled.
 
 ## In-code Symbol Replacement
 
+* If a symbol is used in the code, it will be replaced with its replacement value string before the line of code is compiled.
 * If a symbol is undefined at the time a line of code is being evaluated, an error will be generated indicating an undefined symbol in code.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,9 +13,10 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">=3.9"
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
     "Programming Language :: Python :: 3.9",
+    "Topic :: Software Development :: Assemblers",
 ]
 dependencies = [
     "click",
@@ -34,11 +35,7 @@ changelog = "https://github.com/michaelkamprath/bespokeasm/blob/main/CHANGELOG.m
 [project.scripts]
 bespokeasm = "bespokeasm.__main__:entry_point"
 
-# [tool.setuptools]
-# include-package-data = true
-
 [tool.setuptools.packages.find]
-# namespaces = true
 where = ["src"]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bespokeasm"
-version = "0.3.4"
+version = "0.4.0"
 authors = [
   { name="Michael Kamprath", email="michael@kamprath.net" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bespokeasm"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
   { name="Michael Kamprath", email="michael@kamprath.net" },
 ]

--- a/src/bespokeasm/__init__.py
+++ b/src/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = "0.3.3"
+BESPOKEASM_VERSION_STR = "0.3.4"
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = "0.3.0"

--- a/src/bespokeasm/__init__.py
+++ b/src/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = "0.3.4"
+BESPOKEASM_VERSION_STR = "0.4.0"
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = "0.3.0"

--- a/src/bespokeasm/__main__.py
+++ b/src/bespokeasm/__main__.py
@@ -64,7 +64,7 @@ def main():
         help='Path to use when searching for included asm files. Multiple paths can be seperately specified.'
     )
 @click.option(
-        '--macro-sybol', '-D', multiple=True, default=[],
+        '--macro-symbol', '-D', multiple=True, default=[],
         help='Predefine name as macro. Assigning name with value may be done with "name=value" syntax. '
              'Multiple can be seperately specified.'
     )

--- a/src/bespokeasm/__main__.py
+++ b/src/bespokeasm/__main__.py
@@ -63,6 +63,11 @@ def main():
         '--include-path', '-I', multiple=True, default=[],
         help='Path to use when searching for included asm files. Multiple paths can be seperately specified.'
     )
+@click.option(
+        '--predefined', '-D', multiple=True, default=[],
+        help='Predefine name as macro. Assigning name with value may be done with "name=value" syntax. '
+             'Multiple can be seperately specified.'
+    )
 def compile(
             asm_file,
             config_file,
@@ -75,7 +80,8 @@ def compile(
             pretty_print_format,
             pretty_print_output,
             verbose,
-            include_path
+            include_path,
+            predefined
         ):
     if output_file is None:
         output_file = os.path.splitext(asm_file)[0] + '.bin'
@@ -95,6 +101,7 @@ def compile(
         binary_fill,
         pretty_print, pretty_print_format, pretty_print_output, verbose,
         include_path,
+        predefined,
     )
     asm.assemble_bytecode()
 

--- a/src/bespokeasm/__main__.py
+++ b/src/bespokeasm/__main__.py
@@ -64,7 +64,7 @@ def main():
         help='Path to use when searching for included asm files. Multiple paths can be seperately specified.'
     )
 @click.option(
-        '--predefined', '-D', multiple=True, default=[],
+        '--macro-sybol', '-D', multiple=True, default=[],
         help='Predefine name as macro. Assigning name with value may be done with "name=value" syntax. '
              'Multiple can be seperately specified.'
     )

--- a/src/bespokeasm/__main__.py
+++ b/src/bespokeasm/__main__.py
@@ -81,7 +81,7 @@ def compile(
             pretty_print_output,
             verbose,
             include_path,
-            predefined
+            macro_symbol
         ):
     if output_file is None:
         output_file = os.path.splitext(asm_file)[0] + '.bin'
@@ -101,7 +101,7 @@ def compile(
         binary_fill,
         pretty_print, pretty_print_format, pretty_print_output, verbose,
         include_path,
-        predefined,
+        macro_symbol,
     )
     asm.assemble_bytecode()
 

--- a/src/bespokeasm/assembler/assembly_file.py
+++ b/src/bespokeasm/assembler/assembly_file.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 import click
 import os
-from packaging import version
 import re
 import sys
 
@@ -19,9 +18,7 @@ from bespokeasm.assembler.line_object.directive_line import SetMemoryZoneLine
 from bespokeasm.assembler.line_object.factory import LineOjectFactory
 from bespokeasm.assembler.line_object.label_line import LabelLine
 from bespokeasm.assembler.model import AssemblerModel
-from bespokeasm.assembler.memory_zone import MEMORY_ZONE_NAME_PATTERN
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
-from bespokeasm.utilities import PATTERN_NUMERIC, parse_numeric_string
 from bespokeasm.assembler.preprocessor import Preprocessor
 
 
@@ -64,7 +61,9 @@ class AssemblyFile:
                     line_id = LineIdentifier(line_num, filename=self.filename)
                     line_str = line.strip()
                     if len(line_str) > 0:
-                        # check to see if this is a #include line
+                        # check to see if this is a #include line.
+                        # this is the one preprocessor directive that is handled
+                        # by the assembly file object.
                         if line_str.startswith('#include'):
                             additional_line_objects = self._handle_include_file(
                                 line_str,
@@ -78,22 +77,19 @@ class AssemblyFile:
                             )
                             line_objects.extend(additional_line_objects)
                             continue
-                        if line_str.startswith('#require'):
-                            self._handle_require_language(line_str, line_id, isa_model, log_verbosity)
-                            continue
 
-                        if line_str.startswith('#create_memzone'):
-                            self._handle_create_memzone(line_str, line_id, isa_model, memzone_manager, log_verbosity)
-                            continue
-
-                        lobj_list = LineOjectFactory.parse_line(
+                        lobj_list = []
+                        # parse the line
+                        lobj_list.extend(LineOjectFactory.parse_line(
                             line_id,
                             line_str,
                             isa_model,
                             current_scope,
                             current_memzone,
                             memzone_manager,
-                        )
+                            preprocessor,
+                            log_verbosity,
+                        ))
                         for lobj in lobj_list:
                             if isinstance(lobj, LabelLine):
                                 if not lobj.is_constant \
@@ -104,7 +100,7 @@ class AssemblyFile:
                                 current_scope = self.label_scope
                                 current_memzone = lobj.memory_zone
                             lobj.label_scope = current_scope
-                            # setting constants now so they can be used when evluating lines later.
+                            # setting constants now so they can be used when evaluating lines later.
                             if isinstance(lobj, LabelLine) and lobj.is_constant:
                                 lobj.label_scope.set_label_value(lobj.get_label(), lobj.get_value(), lobj.line_id)
                             line_objects.append(lobj)
@@ -119,18 +115,6 @@ class AssemblyFile:
     PATTERN_INCLUDE_FILE = re.compile(
         r'^\#include\s+(?:\'|\")([\w\.\-\_]+)(?:\'|\")',
         flags=re.IGNORECASE | re.MULTILINE
-    )
-    PATTERN_REQUIRE_LANGUAGE = re.compile(
-        r'\#require\s+\"([\w\-\_\.]*)(?:\s*(==|>=|<=|>|<)\s*({0}))?\"'.format(version.VERSION_PATTERN),
-        flags=re.IGNORECASE | re.VERBOSE
-    )
-
-    PATTERN_CREATE_MEMORY_ZONE = re.compile(
-        r'#create_memzone\s+({0})\s+({1})\s+({2})'.format(
-            MEMORY_ZONE_NAME_PATTERN,
-            PATTERN_NUMERIC,
-            PATTERN_NUMERIC,
-        )
     )
 
     def _handle_include_file(
@@ -165,71 +149,6 @@ class AssemblyFile:
         else:
             sys.exit(f'ERROR: {line_id} - Improperly formatted include directive')
 
-    def _handle_require_language(
-                self,
-                line_str: int,
-                line_id: LineIdentifier,
-                isa_model: AssemblerModel,
-                log_verbosity: int
-            ) -> None:
-        require_match = re.search(AssemblyFile.PATTERN_REQUIRE_LANGUAGE, line_str)
-        if require_match is not None:
-            required_language = require_match.group(1).strip()
-            if required_language != isa_model.isa_name:
-                sys.exit(
-                    f'ERROR: {line_id} - language "{required_language}" is required but ISA '
-                    f'configuration file declares language "{isa_model.isa_name}"'
-                )
-            if len(require_match.groups()) >= 3 and require_match.group(2) is not None and require_match.group(3) is not None:
-                operator_str = require_match.group(2).strip()
-                version_str = require_match.group(3).strip()
-                version_obj = version.parse(version_str)
-                model_version_obj = version.parse(isa_model.isa_version)
-                operator_actions = {
-                    '>=': {
-                        'check': model_version_obj >= version_obj,
-                        'error': f'ERROR: {line_id} - at least language version "{version_str}" is required but '
-                                 f'ISA configuration file declares language version "{isa_model.isa_version}"',
-                    },
-                    '<=': {
-                        'check': model_version_obj <= version_obj,
-                        'error': f'ERROR: {line_id} - up to language version "{version_str}" is required but '
-                                 f'ISA configuration file declares language version "{isa_model.isa_version}"',
-                    },
-                    '>': {
-                        'check': model_version_obj > version_obj,
-                        'error': f'ERROR: {line_id} - greater than language version "{version_str}" is required but '
-                                 f'ISA configuration file declares language version "{isa_model.isa_version}"',
-                    },
-                    '<': {
-                        'check': model_version_obj < version_obj,
-                        'error': f'ERROR: {line_id} - less than language version "{version_str}" is required but '
-                                 f'ISA configuration file declares language version "{isa_model.isa_version}"',
-                    },
-                    '==': {
-                        'check': model_version_obj < version_obj,
-                        'error': f'ERROR: {line_id} - exactly language version "{version_str}" is required but '
-                                 f'ISA configuration file declares language version "{isa_model.isa_version}"',
-                    },
-                }
-
-                if operator_str in operator_actions:
-                    if not operator_actions[operator_str]['check']:
-                        sys.exit(operator_actions[operator_str]['error'])
-                else:
-                    sys.exit(f'ERROR: {line_id} - got a language requirement comparison that is not understood.')
-                if log_verbosity > 1:
-                    print(
-                        f'Code file requires language "{require_match.group(1)} {require_match.group(2)} '
-                        f'{require_match.group(3)}". Configurate file declares language "{isa_model.isa_name} '
-                        f'{isa_model.isa_version}"'
-                    )
-            elif log_verbosity > 1:
-                print(
-                    f'Code file requires language "{require_match.group(1)}". '
-                    f'Configurate file declares language "{isa_model.isa_name} v{isa_model.isa_version}"'
-                )
-
     def _locate_filename(self, filename: str, include_paths: set[str], line_id: LineIdentifier) -> str:
         '''locates the filename in the include paths, and returns the full file path. Errors if file name is ambiguous.'''
         filepath = None
@@ -243,36 +162,3 @@ class AssemblyFile:
         if filepath is None:
             sys.exit(f'ERROR: {line_id} - could not find file "{filename}" to include')
         return filepath
-
-    def _handle_create_memzone(
-        self,
-        line_str: str,
-        line_id: LineIdentifier,
-        isa_model: AssemblerModel,
-        memzone_manager: MemoryZoneManager,
-        log_verbosity: int
-    ) -> None:
-        '''Creates a new memory zone based on the #create_memzone line'''
-        memzone_match = re.search(AssemblyFile.PATTERN_CREATE_MEMORY_ZONE, line_str)
-        if memzone_match is not None and len(memzone_match.groups()) == 3:
-            name = memzone_match.group(1).strip()
-            start_addr = parse_numeric_string(memzone_match.group(2))
-            end_addr = parse_numeric_string(memzone_match.group(3))
-            if log_verbosity > 2:
-                print(
-                    f'Creating memory zone "{name}" with start address {start_addr} '
-                    f'and end address {end_addr}'
-                )
-            try:
-                memzone_manager.create_zone(
-                    isa_model.address_size,
-                    start_addr,
-                    end_addr,
-                    name,
-                )
-            except KeyError:
-                sys.exit(f'ERROR: {line_id} - Memory zone "{name}" defined multiple times')
-            except ValueError as v_err:
-                sys.exit(f'ERROR: {line_id} - {v_err}')
-        else:
-            sys.exit(f'ERROR: {line_id} - Syntax error when creating memory zone')

--- a/src/bespokeasm/assembler/assembly_file.py
+++ b/src/bespokeasm/assembler/assembly_file.py
@@ -22,6 +22,7 @@ from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone import MEMORY_ZONE_NAME_PATTERN
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.utilities import PATTERN_NUMERIC, parse_numeric_string
+from bespokeasm.assembler.preprocessor import Preprocessor
 
 
 class AssemblyFile:
@@ -46,6 +47,7 @@ class AssemblyFile:
                 isa_model: AssemblerModel,
                 include_paths: set[str],
                 memzone_manager: MemoryZoneManager,
+                preprocessor: Preprocessor,
                 log_verbosity: int,
                 assembly_files_used: set = set()
             ) -> list[LineObject]:
@@ -69,6 +71,7 @@ class AssemblyFile:
                                 line_id,
                                 isa_model,
                                 memzone_manager,
+                                preprocessor,
                                 include_paths,
                                 log_verbosity,
                                 assembly_files_used
@@ -136,6 +139,7 @@ class AssemblyFile:
                 line_id: LineIdentifier,
                 isa_model: AssemblerModel,
                 memzone_manager: MemoryZoneManager,
+                preprocessor: Preprocessor,
                 include_paths: set[str],
                 log_verbosity: int,
                 assembly_files_used: set
@@ -154,6 +158,7 @@ class AssemblyFile:
                 isa_model,
                 include_paths,
                 memzone_manager,
+                preprocessor,
                 log_verbosity,
                 assembly_files_used=assembly_files_used
             )

--- a/src/bespokeasm/assembler/assembly_file.py
+++ b/src/bespokeasm/assembler/assembly_file.py
@@ -20,7 +20,7 @@ from bespokeasm.assembler.line_object.label_line import LabelLine
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.preprocessor import Preprocessor
-from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+from bespokeasm.assembler.preprocessor.condition_stack import ConditionStack
 from bespokeasm.assembler.line_object.preprocessor_line.condition_line import ConditionLine
 
 
@@ -58,7 +58,7 @@ class AssemblyFile:
                 line_num = 0
                 current_scope = self.label_scope
                 current_memzone = memzone_manager.global_zone
-                condition_stack = ConsitionStack()
+                condition_stack = ConditionStack()
                 for line in f:
                     line_num += 1
                     line_id = LineIdentifier(line_num, filename=self.filename)

--- a/src/bespokeasm/assembler/engine.py
+++ b/src/bespokeasm/assembler/engine.py
@@ -51,7 +51,8 @@ class Assembler:
             self._model.default_origin,
             self._model.predefined_memory_zones,
         )
-        preprocessor: Preprocessor = Preprocessor()
+
+        preprocessor: Preprocessor = Preprocessor(self._model.predefined_symbols)
 
         # create the predefined memory blocks
         predefines_lineid = LineIdentifier(0, os.path.basename(self._config_file))

--- a/src/bespokeasm/assembler/engine.py
+++ b/src/bespokeasm/assembler/engine.py
@@ -29,6 +29,7 @@ class Assembler:
                 pretty_print_output: str,
                 is_verbose: int,
                 include_paths: list[str],
+                predefined: list[str],
             ):
         self._source_file = source_file
         self._output_file = output_file
@@ -43,6 +44,7 @@ class Assembler:
         self._binary_end = binary_end
         self._model = AssemblerModel(self._config_file, self._verbose)
         self._include_paths = include_paths
+        self._predefined_symbols = predefined
 
     def assemble_bytecode(self):
         global_label_scope = self._model.global_label_scope
@@ -52,7 +54,10 @@ class Assembler:
             self._model.predefined_memory_zones,
         )
 
+        # create preprocessor
         preprocessor: Preprocessor = Preprocessor(self._model.predefined_symbols)
+        # add any predefined macros from the command line
+        preprocessor.add_cli_symbols(self._predefined_symbols)
 
         # create the predefined memory blocks
         predefines_lineid = LineIdentifier(0, os.path.basename(self._config_file))

--- a/src/bespokeasm/assembler/engine.py
+++ b/src/bespokeasm/assembler/engine.py
@@ -11,6 +11,7 @@ from bespokeasm.assembler.line_object.predefined_data import PredefinedDataLine
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.pretty_printer.factory import PrettyPrinterFactory
+from bespokeasm.assembler.preprocessor import Preprocessor
 
 
 class Assembler:
@@ -50,6 +51,8 @@ class Assembler:
             self._model.default_origin,
             self._model.predefined_memory_zones,
         )
+        preprocessor: Preprocessor = Preprocessor()
+
         # create the predefined memory blocks
         predefines_lineid = LineIdentifier(0, os.path.basename(self._config_file))
         predefined_line_obs: list[LineObject] = []
@@ -80,6 +83,7 @@ class Assembler:
             self._model,
             include_dirs,
             memzone_manager,
+            preprocessor,
             self._verbose
         )
 

--- a/src/bespokeasm/assembler/keywords.py
+++ b/src/bespokeasm/assembler/keywords.py
@@ -8,7 +8,8 @@ BYTECODE_DIRECTIVES_SET = set([
 ])
 
 PREPROCESSOR_DIRECTIVES_SET = set([
-    'include', 'require', 'create_memzone'
+    'include', 'require', 'create_memzone',
+    'define', 'if', 'elif', 'else', 'endif', 'ifdef', 'ifndef',
 ])
 
 EXPRESSION_FUNCTIONS_SET = set([

--- a/src/bespokeasm/assembler/line_object/__init__.py
+++ b/src/bespokeasm/assembler/line_object/__init__.py
@@ -18,6 +18,7 @@ class LineObject:
         self._address = None
         self._label_scope = None
         self._memzone = memzone
+        self._compilable = True
 
     def __repr__(self):
         return str(self)
@@ -71,6 +72,15 @@ class LineObject:
     @property
     def memory_zone(self) -> MemoryZone:
         return self._memzone
+
+    @property
+    def compilable(self) -> bool:
+        """Returns True if this line object can be compiled to bytecode"""
+        return self._compilable
+
+    @compilable.setter
+    def compilable(self, value: bool):
+        self._compilable = value
 
 
 class LineWithBytes(LineObject):

--- a/src/bespokeasm/assembler/line_object/directive_line.py
+++ b/src/bespokeasm/assembler/line_object/directive_line.py
@@ -5,7 +5,7 @@ from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineWithBytes, LineObject, INSTRUCTION_EXPRESSION_PATTERN
 from bespokeasm.assembler.line_object.data_line import DataLine
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager, GLOBAL_ZONE_NAME
-from bespokeasm.expression import parse_expression, ExpresionType
+from bespokeasm.expression import parse_expression, ExpressionNode
 from bespokeasm.assembler.memory_zone import MEMORY_ZONE_NAME_PATTERN, MemoryZone
 
 # Directives are lines that tell the assembler to do something. Supported directives are:
@@ -194,8 +194,8 @@ class AddressOrgLine(SetMemoryZoneLine):
 
 
 class FillDataLine(LineWithBytes):
-    _count_expr: ExpresionType
-    _value_expr: ExpresionType
+    _count_expr: ExpressionNode
+    _value_expr: ExpressionNode
 
     def __init__(
             self,
@@ -227,8 +227,8 @@ class FillDataLine(LineWithBytes):
 
 
 class FillUntilDataLine(LineWithBytes):
-    _fill_until_addr_expr: ExpresionType
-    _fill_value_expr: ExpresionType
+    _fill_until_addr_expr: ExpressionNode
+    _fill_value_expr: ExpressionNode
     _fill_until_addr: int
     _fill_value: int
 

--- a/src/bespokeasm/assembler/line_object/factory.py
+++ b/src/bespokeasm/assembler/line_object/factory.py
@@ -68,7 +68,7 @@ class LineOjectFactory:
                 ))
         else:
             # resolve proprocessor symbols
-            instruction_str = preprocessor.resolve_symbols(instruction_str)
+            instruction_str = preprocessor.resolve_symbols(line_id, instruction_str)
             # parse instruction
             while len(instruction_str) > 0:
                 # try label

--- a/src/bespokeasm/assembler/line_object/factory.py
+++ b/src/bespokeasm/assembler/line_object/factory.py
@@ -12,7 +12,7 @@ from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.preprocessor import Preprocessor
 from bespokeasm.assembler.line_object.preprocessor_line.factory import PreprocessorLineFactory
-from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+from bespokeasm.assembler.preprocessor.condition_stack import ConditionStack
 
 
 class LineOjectFactory:
@@ -35,7 +35,7 @@ class LineOjectFactory:
                 current_memzone: MemoryZone,
                 memzone_manager: MemoryZoneManager,
                 preprocessor: Preprocessor,
-                condition_stack: ConsitionStack,
+                condition_stack: ConditionStack,
                 log_verbosity: int,
             ) -> list[LineObject]:
         # find comments

--- a/src/bespokeasm/assembler/line_object/factory.py
+++ b/src/bespokeasm/assembler/line_object/factory.py
@@ -12,6 +12,7 @@ from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.preprocessor import Preprocessor
 from bespokeasm.assembler.line_object.preprocessor_line.factory import PreprocessorLineFactory
+from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
 
 
 class LineOjectFactory:
@@ -34,6 +35,7 @@ class LineOjectFactory:
                 current_memzone: MemoryZone,
                 memzone_manager: MemoryZoneManager,
                 preprocessor: Preprocessor,
+                condition_stack: ConsitionStack,
                 log_verbosity: int,
             ) -> list[LineObject]:
         # find comments
@@ -61,6 +63,7 @@ class LineOjectFactory:
                     current_memzone,
                     memzone_manager,
                     preprocessor,
+                    condition_stack,
                     log_verbosity,
                 ))
         else:

--- a/src/bespokeasm/assembler/line_object/factory.py
+++ b/src/bespokeasm/assembler/line_object/factory.py
@@ -67,6 +67,8 @@ class LineOjectFactory:
                     log_verbosity,
                 ))
         else:
+            # resolve proprocessor symbols
+            instruction_str = preprocessor.resolve_symbols(instruction_str)
             # parse instruction
             while len(instruction_str) > 0:
                 # try label

--- a/src/bespokeasm/assembler/line_object/factory.py
+++ b/src/bespokeasm/assembler/line_object/factory.py
@@ -11,6 +11,7 @@ from bespokeasm.assembler.line_object.instruction_line import InstructionLine
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.preprocessor import Preprocessor
+from bespokeasm.assembler.line_object.preprocessor_line.factory import PreprocessorLineFactory
 
 
 class LineOjectFactory:
@@ -51,7 +52,7 @@ class LineOjectFactory:
         # check to see if this is preprocessor directive
         if instruction_str.startswith('#'):
             # this is a preprocessor directive
-            line_obj_list.extend(preprocessor.parse_line(
+            line_obj_list.extend(PreprocessorLineFactory.parse_line(
                     line_id,
                     instruction_str,
                     comment_str,
@@ -59,6 +60,7 @@ class LineOjectFactory:
                     label_scope,
                     current_memzone,
                     memzone_manager,
+                    preprocessor,
                     log_verbosity,
                 ))
         else:

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/__init__.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/__init__.py
@@ -1,0 +1,11 @@
+from bespokeasm.assembler.line_object import LineObject
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.memory_zone import MemoryZone
+
+
+class PreprocessorLine(LineObject):
+    def __init__(self, line_id: LineIdentifier, instruction: str, comment: str, memzone: MemoryZone):
+        super().__init__(line_id, instruction, comment, memzone)
+
+    def __repr__(self) -> str:
+        return f"PreprocessorLine<{self._line_id}>"

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/condition_line.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/condition_line.py
@@ -2,7 +2,7 @@ from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.memory_zone import MemoryZone
 import bespokeasm.assembler.preprocessor.condition as condition
-from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+from bespokeasm.assembler.preprocessor.condition_stack import ConditionStack
 
 
 CONDITIONAL_LINE_PREFIX_LIST = ["#if ", "#ifdef ", "#ifndef ", "#elif ", "#else", "#endif"]
@@ -15,7 +15,7 @@ class ConditionLine(PreprocessorLine):
                 instruction: str,
                 comment: str,
                 memzone: MemoryZone,
-                condition_stack: ConsitionStack
+                condition_stack: ConditionStack
             ):
         super().__init__(line_id, instruction, comment, memzone)
 

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/condition_line.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/condition_line.py
@@ -1,0 +1,40 @@
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.memory_zone import MemoryZone
+import bespokeasm.assembler.preprocessor.condition as condition
+from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+
+
+CONDITIONAL_LINE_PREFIX_LIST = ["#if ", "#ifdef ", "#ifndef ", "#else", "#endif"]
+
+
+class ConditionLine(PreprocessorLine):
+    def __init__(
+                self,
+                line_id: LineIdentifier,
+                instruction: str,
+                comment: str,
+                memzone: MemoryZone,
+                condition_stack: ConsitionStack
+            ):
+        super().__init__(line_id, instruction, comment, memzone)
+
+        if instruction.startswith("#if "):
+            self._condition = condition.IfPreprocessorCondition(instruction, line_id)
+        elif instruction == "#else":
+            self._condition = condition.ElsePreprocessorCondition(instruction, line_id)
+        elif instruction == "#endif":
+            self._condition = condition.EndifPreprocessorCondition(instruction, line_id)
+        elif instruction.startswith("#ifdef ") or instruction.startswith("#ifndef "):
+            self._condition = condition.IfdefPreprocessorCondition(instruction, line_id)
+        else:
+            raise ValueError(f"Invalid condition line: {instruction}")
+
+        condition_stack.process_condition(self._condition)
+
+    def __repr__(self) -> str:
+        return f"ConditionLine<{self._line_id}>"
+
+    @property
+    def compilable(self) -> bool:
+        return True

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/condition_line.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/condition_line.py
@@ -5,7 +5,7 @@ import bespokeasm.assembler.preprocessor.condition as condition
 from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
 
 
-CONDITIONAL_LINE_PREFIX_LIST = ["#if ", "#ifdef ", "#ifndef ", "#else", "#endif"]
+CONDITIONAL_LINE_PREFIX_LIST = ["#if ", "#ifdef ", "#ifndef ", "#elif ", "#else", "#endif"]
 
 
 class ConditionLine(PreprocessorLine):
@@ -21,6 +21,8 @@ class ConditionLine(PreprocessorLine):
 
         if instruction.startswith("#if "):
             self._condition = condition.IfPreprocessorCondition(instruction, line_id)
+        elif instruction.startswith("#elif "):
+            self._condition = condition.ElifPreprocessorCondition(instruction, line_id)
         elif instruction == "#else":
             self._condition = condition.ElsePreprocessorCondition(instruction, line_id)
         elif instruction == "#endif":

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/create_memzone.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/create_memzone.py
@@ -1,0 +1,59 @@
+import re
+import sys
+
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
+from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.assembler.memory_zone import MEMORY_ZONE_NAME_PATTERN
+from bespokeasm.utilities import PATTERN_NUMERIC, parse_numeric_string
+
+
+class CreateMemzoneLine(PreprocessorLine):
+    PATTERN_CREATE_MEMORY_ZONE = re.compile(
+        r'#create_memzone\s+({0})\s+({1})\s+({2})'.format(
+            MEMORY_ZONE_NAME_PATTERN,
+            PATTERN_NUMERIC,
+            PATTERN_NUMERIC,
+        ),
+    )
+
+    def __init__(
+        self,
+        line_id: LineIdentifier,
+        instruction: str,
+        comment: str,
+        memzone: MemoryZone,
+        memzone_manager: MemoryZoneManager,
+        isa_model: AssemblerModel,
+        log_verbosity: int
+    ) -> None:
+        '''Creates a new memory zone based on the #create_memzone line'''
+        super().__init__(line_id, instruction, comment, memzone)
+        memzone_match = re.search(CreateMemzoneLine.PATTERN_CREATE_MEMORY_ZONE, instruction)
+        if memzone_match is not None and len(memzone_match.groups()) == 3:
+            self._name = memzone_match.group(1).strip()
+            self._start_addr = parse_numeric_string(memzone_match.group(2))
+            self._end_addr = parse_numeric_string(memzone_match.group(3))
+            if log_verbosity > 2:
+                print(
+                    f'Creating memory zone "{self._name}" with start address {self._start_addr} '
+                    f'and end address {self._end_addr}'
+                )
+            try:
+                memzone_manager.create_zone(
+                    isa_model.address_size,
+                    self._start_addr,
+                    self._end_addr,
+                    self._name,
+                )
+            except KeyError:
+                sys.exit(f'ERROR: {line_id} - Memory zone "{self._name}" defined multiple times')
+            except ValueError as v_err:
+                sys.exit(f'ERROR: {line_id} - {v_err}')
+        else:
+            sys.exit(f'ERROR: {line_id} - Syntax error when creating memory zone')
+
+    def __repr__(self) -> str:
+        return f"CreateMemzoneLine<{self._name}: {self._start_addr} -> {self._end_addr}>"

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/define_symbol.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/define_symbol.py
@@ -12,7 +12,7 @@ from bespokeasm.assembler.preprocessor.symbol import PreprocessorSymbol, SYMBOL_
 
 class DefineSymbolLine(PreprocessorLine):
     PATTERN_DEFINE_SYMBOL = re.compile(
-            r'^#define\s+({0})(?:\s+((?:[a-zA-Z0-9_]*|\".*\"|\'.*\'|\(.*\)))|\b)$'.format(SYMBOL_PATTERN),
+            r'^#define\s+({0})(?:\s+(\S.*?))?\s*$'.format(SYMBOL_PATTERN),
         )
 
     def __init__(

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/define_symbol.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/define_symbol.py
@@ -12,7 +12,7 @@ from bespokeasm.assembler.preprocessor.symbol import PreprocessorSymbol, SYMBOL_
 
 class DefineSymbolLine(PreprocessorLine):
     PATTERN_DEFINE_SYMBOL = re.compile(
-            r'^#define\s+({0})\s+(?:((?:[a-zA-Z0-9_]*|\".*\"|\'.*\'|\(.*\)))|)$'.format(SYMBOL_PATTERN),
+            r'^#define\s+({0})(?:\s+((?:[a-zA-Z0-9_]*|\".*\"|\'.*\'|\(.*\)))|\b)$'.format(SYMBOL_PATTERN),
         )
 
     def __init__(
@@ -42,7 +42,7 @@ class DefineSymbolLine(PreprocessorLine):
             if log_verbosity >= 2:
                 print(f'INFO - {line_id}: Defined preprocessor symbol {self._symbol.name} = {self._symbol.value}')
         else:
-            sys.exit(f'ERROR - {line_id}: Invalid preprocessor symbol definition.')
+            sys.exit(f'ERROR - {line_id}: Invalid preprocessor symbol definition: {instruction}')
 
     def __repr__(self) -> str:
         return f"DefineSymbolLine<{self._symbol}>"

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/define_symbol.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/define_symbol.py
@@ -1,0 +1,52 @@
+import re
+import sys
+
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
+from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.assembler.preprocessor import Preprocessor
+from bespokeasm.assembler.preprocessor.symbol import PreprocessorSymbol, SYMBOL_PATTERN
+
+
+class DefineSymbolLine(PreprocessorLine):
+    PATTERN_DEFINE_SYMBOL = re.compile(
+            r'^#define\s+({0})\s+(?:((?:[a-zA-Z0-9_]*|\".*\"|\'.*\'|\(.*\)))|)$'.format(SYMBOL_PATTERN),
+        )
+
+    def __init__(
+        self,
+        line_id: LineIdentifier,
+        instruction: str,
+        comment: str,
+        memzone: MemoryZone,
+        memzone_manager: MemoryZoneManager,
+        isa_model: AssemblerModel,
+        preprocessor: Preprocessor,
+        log_verbosity: int
+    ) -> None:
+        '''Defines a new preprocessor symbol.'''
+        super().__init__(line_id, instruction, comment, memzone)
+        define_match = re.search(DefineSymbolLine.PATTERN_DEFINE_SYMBOL, instruction.strip())
+        if define_match is not None:
+            try:
+                if len(define_match.groups()) == 1:
+                    self._symbol = preprocessor.create_symbol(define_match.group(1), None, line_id)
+                elif len(define_match.groups()) == 2:
+                    self._symbol = preprocessor.create_symbol(define_match.group(1), define_match.group(2), line_id)
+                else:
+                    sys.exit(f'ERROR - {line_id}: Invalid preprocessor symbol definition.')
+            except ValueError:
+                sys.exit(f'ERROR - {line_id}: Preprocessor symbol {define_match.group(1)} is defined multiple times.')
+            if log_verbosity >= 2:
+                print(f'INFO - {line_id}: Defined preprocessor symbol {self._symbol.name} = {self._symbol.value}')
+        else:
+            sys.exit(f'ERROR - {line_id}: Invalid preprocessor symbol definition.')
+
+    def __repr__(self) -> str:
+        return f"DefineSymbolLine<{self._symbol}>"
+
+    @property
+    def symbol(self) -> PreprocessorSymbol:
+        return self._symbol

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
@@ -1,0 +1,60 @@
+from bespokeasm.assembler.line_object import LineObject
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
+from bespokeasm.assembler.preprocessor import Preprocessor
+from bespokeasm.assembler.line_object.preprocessor_line.required_language import RequiredLanguageLine
+from bespokeasm.assembler.line_object.preprocessor_line.create_memzone import CreateMemzoneLine
+from bespokeasm.assembler.line_object.preprocessor_line.define_symbol import DefineSymbolLine
+
+
+class PreprocessorLineFactory:
+    @classmethod
+    def parse_line(
+        cls,
+        line_id: LineIdentifier,
+        instruction: str,
+        comment: str,
+        isa_model: AssemblerModel,
+        label_scope: LabelScope,
+        current_memzone: MemoryZone,
+        memzone_manager: MemoryZoneManager,
+        preprocessor: Preprocessor,
+        log_verbosity: int,
+    ) -> list[LineObject]:
+        '''Parse a preprocessor line.'''
+        if instruction.startswith('#require '):
+            return [RequiredLanguageLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        isa_model,
+                        log_verbosity
+                    )]
+
+        if instruction.startswith('#create_memzone '):
+            return [CreateMemzoneLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        memzone_manager,
+                        isa_model,
+                        log_verbosity,
+                    )]
+
+        if instruction.startswith('#define '):
+            return [DefineSymbolLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        memzone_manager,
+                        isa_model,
+                        preprocessor,
+                        log_verbosity,
+                    )]
+        return []

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
@@ -9,7 +9,7 @@ from bespokeasm.assembler.line_object.preprocessor_line.required_language import
 from bespokeasm.assembler.line_object.preprocessor_line.create_memzone import CreateMemzoneLine
 from bespokeasm.assembler.line_object.preprocessor_line.define_symbol import DefineSymbolLine
 from bespokeasm.assembler.line_object.preprocessor_line.condition_line import ConditionLine, CONDITIONAL_LINE_PREFIX_LIST
-from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+from bespokeasm.assembler.preprocessor.condition_stack import ConditionStack
 
 
 class PreprocessorLineFactory:
@@ -24,7 +24,7 @@ class PreprocessorLineFactory:
         current_memzone: MemoryZone,
         memzone_manager: MemoryZoneManager,
         preprocessor: Preprocessor,
-        condition_stack: ConsitionStack,
+        condition_stack: ConditionStack,
         log_verbosity: int,
     ) -> list[LineObject]:
         '''Parse a preprocessor line.'''

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
@@ -8,6 +8,8 @@ from bespokeasm.assembler.preprocessor import Preprocessor
 from bespokeasm.assembler.line_object.preprocessor_line.required_language import RequiredLanguageLine
 from bespokeasm.assembler.line_object.preprocessor_line.create_memzone import CreateMemzoneLine
 from bespokeasm.assembler.line_object.preprocessor_line.define_symbol import DefineSymbolLine
+from bespokeasm.assembler.line_object.preprocessor_line.condition_line import ConditionLine, CONDITIONAL_LINE_PREFIX_LIST
+from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
 
 
 class PreprocessorLineFactory:
@@ -22,6 +24,7 @@ class PreprocessorLineFactory:
         current_memzone: MemoryZone,
         memzone_manager: MemoryZoneManager,
         preprocessor: Preprocessor,
+        condition_stack: ConsitionStack,
         log_verbosity: int,
     ) -> list[LineObject]:
         '''Parse a preprocessor line.'''
@@ -56,5 +59,13 @@ class PreprocessorLineFactory:
                         isa_model,
                         preprocessor,
                         log_verbosity,
+                    )]
+        if instruction.startswith(tuple(CONDITIONAL_LINE_PREFIX_LIST)):
+            return [ConditionLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        condition_stack,
                     )]
         return []

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/required_language.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/required_language.py
@@ -1,0 +1,94 @@
+from packaging import version
+import operator
+import re
+import sys
+
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.model import AssemblerModel
+
+
+class RequiredLanguageLine(PreprocessorLine):
+    PATTERN_REQUIRE_LANGUAGE = re.compile(
+        r'\#require\s+\"([\w\-\_\.]*)(?:\s*(==|>=|<=|>|<)\s*({0}))?\"'.format(version.VERSION_PATTERN),
+        flags=re.IGNORECASE | re.VERBOSE
+    )
+
+    COMPARISON_ACTIONS = {
+        '>=': {
+            'check': operator.ge,
+            'error': 'ERROR: {0} - at least language version "{1}" is required but '
+                     'ISA configuration file declares language version "{2}"',
+        },
+        '<=': {
+            'check': operator.le,
+            'error': 'ERROR: {0} - up to language version "{1}" is required but '
+                     'ISA configuration file declares language version "{2}"',
+        },
+        '>': {
+            'check': operator.gt,
+            'error': 'ERROR: {0} - greater than language version "{1}" is required but '
+                     'ISA configuration file declares language version "{2}"',
+        },
+        '<': {
+            'check': operator.lt,
+            'error': 'ERROR: {0} - less than language version "{1}" is required but '
+                     'ISA configuration file declares language version "{2}"',
+        },
+        '==': {
+            'check': operator.eq,
+            'error': 'ERROR: {0} - exactly language version "{1}" is required but '
+                     'ISA configuration file declares language version "{2}"',
+        },
+    }
+
+    def __init__(
+                self,
+                line_id: LineIdentifier,
+                instruction: str,
+                comment: str,
+                memzone: MemoryZone,
+                isa_model: AssemblerModel,
+                log_verbosity: int
+            ):
+        super().__init__(line_id, instruction, comment, memzone)
+        require_match = re.search(RequiredLanguageLine.PATTERN_REQUIRE_LANGUAGE, instruction)
+        if require_match is not None:
+            self._language = require_match.group(1).strip()
+            if self._language != isa_model.isa_name:
+                sys.exit(
+                    f'ERROR: {line_id} - language "{self._language}" is required but ISA '
+                    f'configuration file declares language "{isa_model.isa_name}"'
+                )
+            if len(require_match.groups()) >= 3 and require_match.group(2) is not None and require_match.group(3) is not None:
+                self._operator_str = require_match.group(2).strip()
+                version_str = require_match.group(3).strip()
+                self._version_obj = version.parse(version_str)
+                model_version_obj = version.parse(isa_model.isa_version)
+
+                if self._operator_str in RequiredLanguageLine.COMPARISON_ACTIONS:
+                    if not RequiredLanguageLine.COMPARISON_ACTIONS[self._operator_str]['check'](
+                                model_version_obj, self._version_obj
+                            ):
+                        sys.exit(
+                            RequiredLanguageLine.COMPARISON_ACTIONS[self._operator_str]['error'].format(
+                                line_id, version_str, isa_model.isa_version
+                            )
+                        )
+                else:
+                    sys.exit(f'ERROR: {line_id} - got a language requirement comparison that is not understood.')
+                if log_verbosity > 1:
+                    print(
+                        f'Code file requires language "{require_match.group(1)} {require_match.group(2)} '
+                        f'{require_match.group(3)}". Configurate file declares language "{isa_model.isa_name} '
+                        f'{isa_model.isa_version}"'
+                    )
+            elif log_verbosity > 1:
+                print(
+                    f'Code file requires language "{require_match.group(1)}". '
+                    f'Configurate file declares language "{isa_model.isa_name} v{isa_model.isa_version}"'
+                )
+
+    def __repr__(self) -> str:
+        return f"RequiredLanguageLine<{self._language} {self._operator_str} {self._version_obj}>"

--- a/src/bespokeasm/assembler/model/__init__.py
+++ b/src/bespokeasm/assembler/model/__init__.py
@@ -13,7 +13,6 @@ from bespokeasm.assembler.model.instruction_set import InstructionSet
 from bespokeasm.assembler.model.operand_set import OperandSet, OperandSetCollection
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.assembler.line_identifier import LineIdentifier
-from bespokeasm.assembler.preprocessor import Preprocessor
 
 
 class AssemblerModel:
@@ -238,16 +237,8 @@ class AssemblerModel:
         return self._global_label_scope
 
     @property
-    def preprocessor_symbols(self) -> Preprocessor:
-        if self._preprocessor_symbols is None:
-            self._preprocessor_symbols = Preprocessor()
-            if 'predefined' in self._config and 'symbols' in self._config['predefined']:
-                for symbol_def in self._config['predefined']['symbols']:
-                    try:
-                        self._preprocessor_symbols.create_symbol(symbol_def['name'], symbol_def.get('value', ''))
-                    except ValueError:
-                        sys.exit(
-                            f'ERROR: Preprocessor symbol {symbol_def["name"]} is defined multiple times in '
-                            f'instruction set configuration YAML file.'
-                        )
-        return self._preprocessor_symbols
+    def predefined_symbols(self) -> list[dict]:
+        if 'predefined' in self._config and 'symbols' in self._config['predefined']:
+            return self._config['predefined']['symbols']
+        else:
+            return []

--- a/src/bespokeasm/assembler/model/__init__.py
+++ b/src/bespokeasm/assembler/model/__init__.py
@@ -13,6 +13,7 @@ from bespokeasm.assembler.model.instruction_set import InstructionSet
 from bespokeasm.assembler.model.operand_set import OperandSet, OperandSetCollection
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.preprocessor import Preprocessor
 
 
 class AssemblerModel:
@@ -235,3 +236,18 @@ class AssemblerModel:
                 value: int = predefined_constant['value']
                 self._global_label_scope.set_label_value(label, value, predefines_lineid)
         return self._global_label_scope
+
+    @property
+    def preprocessor_symbols(self) -> Preprocessor:
+        if self._preprocessor_symbols is None:
+            self._preprocessor_symbols = Preprocessor()
+            if 'predefined' in self._config and 'symbols' in self._config['predefined']:
+                for symbol_def in self._config['predefined']['symbols']:
+                    try:
+                        self._preprocessor_symbols.create_symbol(symbol_def['name'], symbol_def.get('value', ''))
+                    except ValueError:
+                        sys.exit(
+                            f'ERROR: Preprocessor symbol {symbol_def["name"]} is defined multiple times in '
+                            f'instruction set configuration YAML file.'
+                        )
+        return self._preprocessor_symbols

--- a/src/bespokeasm/assembler/model/__init__.py
+++ b/src/bespokeasm/assembler/model/__init__.py
@@ -77,7 +77,9 @@ class AssemblerModel:
     def _validate_config(self, is_verbose: int) -> None:
         '''Performs some validation checks on configuration dictionary'''
         # check to see if old-style "memory block" is defined
-        if 'predefined' in self._config and 'memory' in self._config['predefined']:
+        if 'predefined' in self._config \
+                and self._config['predefined'] is not None \
+                and 'memory' in self._config['predefined']:
             sys.exit(
                 'ERROR - ISA configuration file defines a predefined "memory" block. '
                 'Memory blocks have been deprecated and replaced with "data" blocks.'
@@ -219,7 +221,9 @@ class AssemblerModel:
 
     @cached_property
     def predefined_memory_zones(self) -> list[dict]:
-        if 'predefined' in self._config and 'memory_zones' in self._config['predefined']:
+        if 'predefined' in self._config \
+                and self._config['predefined'] is not None \
+                and 'memory_zones' in self._config['predefined']:
             return self._config['predefined']['memory_zones']
         else:
             return []

--- a/src/bespokeasm/assembler/preprocessor/__init__.py
+++ b/src/bespokeasm/assembler/preprocessor/__init__.py
@@ -23,9 +23,6 @@ class Preprocessor:
         # Errors if there are recursion loops caused byt symbols that indirectly refer to themselves.
 
         # to make this fast, all symbol candidates should be identified first, then the symbols should be resolved
-        print(
-            f"Resolving symbols in line: {line_str} (symbols: {self._symbols.keys()})",
-        )
         found_symbols: list[str] = re.findall(r"\b([\w\d_]+)\b", line_str)
         symbol_replaced: bool = False
         for s in found_symbols:

--- a/src/bespokeasm/assembler/preprocessor/__init__.py
+++ b/src/bespokeasm/assembler/preprocessor/__init__.py
@@ -1,11 +1,33 @@
 import re
+import sys
 
 from bespokeasm.assembler.preprocessor.symbol import PreprocessorSymbol
+from bespokeasm.assembler.line_object import LineObject
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
+from bespokeasm.assembler.line_object.preprocessor_line.required_language import RequiredLanguageLine
+from bespokeasm.assembler.line_object.preprocessor_line.create_memzone import CreateMemzoneLine
 
 
 class Preprocessor:
-    def __init__(self):
+    def __init__(self, predefined_symbols: dict[str, str] = {}) -> None:
         self._symbols: dict[str, PreprocessorSymbol] = {}
+        for symbol_def in predefined_symbols:
+            if 'name' not in symbol_def:
+                sys.exit(
+                    'ERROR: Preprocessor symbol definition in instruction set configuration YAML file '
+                    'is missing the required "name" field.'
+                )
+            try:
+                self.create_symbol(symbol_def['name'], symbol_def.get('value', ''))
+            except ValueError:
+                sys.exit(
+                    f'ERROR: Preprocessor symbol {symbol_def["name"]} is defined multiple times in '
+                    f'instruction set configuration YAML file.'
+                )
 
     def create_symbol(self, name: str, value: str) -> PreprocessorSymbol:
         if name not in self._symbols:
@@ -35,3 +57,37 @@ class Preprocessor:
             return self.resolve_symbols(line_str)
         else:
             return line_str
+
+    def parse_line(
+                self,
+                line_id: LineIdentifier,
+                instruction: str,
+                comment: str,
+                isa_model: AssemblerModel,
+                label_scope: LabelScope,
+                current_memzone: MemoryZone,
+                memzone_manager: MemoryZoneManager,
+                log_verbosity: int,
+            ) -> list[LineObject]:
+        '''Parse a preprocessor line.'''
+        if instruction.startswith('#require '):
+            return [RequiredLanguageLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        isa_model,
+                        log_verbosity
+                    )]
+
+        if instruction.startswith('#create_memzone '):
+            return [CreateMemzoneLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        memzone_manager,
+                        isa_model,
+                        log_verbosity,
+                    )]
+        return []

--- a/src/bespokeasm/assembler/preprocessor/__init__.py
+++ b/src/bespokeasm/assembler/preprocessor/__init__.py
@@ -2,14 +2,8 @@ import re
 import sys
 
 from bespokeasm.assembler.preprocessor.symbol import PreprocessorSymbol
-from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_identifier import LineIdentifier
-from bespokeasm.assembler.memory_zone import MemoryZone
-from bespokeasm.assembler.model import AssemblerModel
-from bespokeasm.assembler.label_scope import LabelScope
-from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
-from bespokeasm.assembler.line_object.preprocessor_line.required_language import RequiredLanguageLine
-from bespokeasm.assembler.line_object.preprocessor_line.create_memzone import CreateMemzoneLine
+from bespokeasm.assembler.preprocessor.symbol import SYMBOL_PATTERN
 
 
 class Preprocessor:
@@ -29,9 +23,9 @@ class Preprocessor:
                     f'instruction set configuration YAML file.'
                 )
 
-    def create_symbol(self, name: str, value: str) -> PreprocessorSymbol:
+    def create_symbol(self, name: str, value: str, line_id: LineIdentifier = None) -> PreprocessorSymbol:
         if name not in self._symbols:
-            symbol = PreprocessorSymbol(name, value)
+            symbol = PreprocessorSymbol(name, value, line_id)
             self._symbols[name] = symbol
             return symbol
         else:
@@ -45,7 +39,7 @@ class Preprocessor:
         # Errors if there are recursion loops caused byt symbols that indirectly refer to themselves.
 
         # to make this fast, all symbol candidates should be identified first, then the symbols should be resolved
-        found_symbols: list[str] = re.findall(r"\b([\w\d_]+)\b", line_str)
+        found_symbols: list[str] = re.findall(f'\\b({SYMBOL_PATTERN})\\b', line_str)
         symbol_replaced: bool = False
         for s in found_symbols:
             symbol = self.get_symbol(s)
@@ -57,37 +51,3 @@ class Preprocessor:
             return self.resolve_symbols(line_str)
         else:
             return line_str
-
-    def parse_line(
-                self,
-                line_id: LineIdentifier,
-                instruction: str,
-                comment: str,
-                isa_model: AssemblerModel,
-                label_scope: LabelScope,
-                current_memzone: MemoryZone,
-                memzone_manager: MemoryZoneManager,
-                log_verbosity: int,
-            ) -> list[LineObject]:
-        '''Parse a preprocessor line.'''
-        if instruction.startswith('#require '):
-            return [RequiredLanguageLine(
-                        line_id,
-                        instruction,
-                        comment,
-                        current_memzone,
-                        isa_model,
-                        log_verbosity
-                    )]
-
-        if instruction.startswith('#create_memzone '):
-            return [CreateMemzoneLine(
-                        line_id,
-                        instruction,
-                        comment,
-                        current_memzone,
-                        memzone_manager,
-                        isa_model,
-                        log_verbosity,
-                    )]
-        return []

--- a/src/bespokeasm/assembler/preprocessor/__init__.py
+++ b/src/bespokeasm/assembler/preprocessor/__init__.py
@@ -23,6 +23,14 @@ class Preprocessor:
                     f'instruction set configuration YAML file.'
                 )
 
+    def add_cli_symbols(self, cli_symbols: list[str]) -> None:
+        for symbol_str in cli_symbols:
+            if '=' in symbol_str:
+                name, value = symbol_str.split('=')
+                self.create_symbol(name.strip(), value.strip())
+            else:
+                self.create_symbol(symbol_str.strip(), None)
+
     def create_symbol(self, name: str, value: str, line_id: LineIdentifier = None) -> PreprocessorSymbol:
         if name not in self._symbols:
             symbol = PreprocessorSymbol(name, value, line_id)

--- a/src/bespokeasm/assembler/preprocessor/__init__.py
+++ b/src/bespokeasm/assembler/preprocessor/__init__.py
@@ -1,0 +1,17 @@
+from bespokeasm.assembler.preprocessor.symbol import PreprocessorSymbol
+
+
+class Preprocessor:
+    def __init__(self):
+        self._symbols: dict[str, PreprocessorSymbol] = {}
+
+    def create_symbol(self, name: str, value: str) -> PreprocessorSymbol:
+        if name not in self._symbols:
+            symbol = PreprocessorSymbol(name, value)
+            self._symbols[name] = symbol
+            return symbol
+        else:
+            raise ValueError(f"Symbol {name} already exists")
+
+    def get_symbol(self, name: str) -> PreprocessorSymbol:
+        return self._symbols.get(name, None)

--- a/src/bespokeasm/assembler/preprocessor/__init__.py
+++ b/src/bespokeasm/assembler/preprocessor/__init__.py
@@ -1,3 +1,5 @@
+import re
+
 from bespokeasm.assembler.preprocessor.symbol import PreprocessorSymbol
 
 
@@ -15,3 +17,24 @@ class Preprocessor:
 
     def get_symbol(self, name: str) -> PreprocessorSymbol:
         return self._symbols.get(name, None)
+
+    def resolve_symbols(self, line_str: str) -> str:
+        # Resursively resolve symbols in the line string, stopping when there are no more symbols to resolve.
+        # Errors if there are recursion loops caused byt symbols that indirectly refer to themselves.
+
+        # to make this fast, all symbol candidates should be identified first, then the symbols should be resolved
+        print(
+            f"Resolving symbols in line: {line_str} (symbols: {self._symbols.keys()})",
+        )
+        found_symbols: list[str] = re.findall(r"\b([\w\d_]+)\b", line_str)
+        symbol_replaced: bool = False
+        for s in found_symbols:
+            symbol = self.get_symbol(s)
+            if symbol is not None:
+                line_str = line_str.replace(s, symbol.value)
+                symbol_replaced = True
+
+        if symbol_replaced:
+            return self.resolve_symbols(line_str)
+        else:
+            return line_str

--- a/src/bespokeasm/assembler/preprocessor/condition.py
+++ b/src/bespokeasm/assembler/preprocessor/condition.py
@@ -1,0 +1,67 @@
+import re
+
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.preprocessor import Preprocessor
+from bespokeasm.expression import parse_expression, ExpressionNode
+from bespokeasm.assembler.line_object import INSTRUCTION_EXPRESSION_PATTERN
+
+
+# NOTE: the order of the RHS expressions is important, as it determines the order of evaluation. Need to parse the
+#       quoted strings first, then the expressions.
+PREPROCESSOR_CONDITION_IF_PATTERN = re.compile(
+    f"^(?:#if)\\s+([\\w\\d_]+)\\s+(==|!=|>|>=|<|<=)\\s+"
+    f"(?:(?:\\\')(.+)(?:\\\')|(?:\\\")(.+)(?:\\\")|({INSTRUCTION_EXPRESSION_PATTERN}))"
+)
+
+
+class PreprocessorCondition:
+    def __init__(self, line_str: str, line: LineIdentifier):
+        self._line_str = line_str
+        self._line = line
+
+        match = PREPROCESSOR_CONDITION_IF_PATTERN.match(line_str.strip())
+        if match is None:
+            raise ValueError(f"Invalid preprocessor condition at line: {line_str}")
+
+        self._lhs_expression = match.group(1)
+        self._operator = match.group(2)
+        self._rhs_expression = match.group(3) or match.group(4) or match.group(5)
+
+    def __repr__(self) -> str:
+        return f"PreprocessorCondition<#if {self._lhs_symbol} {self._operator} {self._rhs_expression}>"
+
+    def __str__(self) -> str:
+        return self.__repr__()
+
+    def evaluate(self, preprocess: Preprocessor) -> bool:
+        lhs_resolved = preprocess.resolve_symbols(self._lhs_expression)
+        rhs_resolved = preprocess.resolve_symbols(self._rhs_expression)
+
+        lhs_expression: ExpressionNode = parse_expression(self._line, lhs_resolved)
+        rhs_expression: ExpressionNode = parse_expression(self._line, rhs_resolved)
+
+        if len(lhs_expression.contained_labels()) > 0 or len(rhs_expression.contained_labels()) > 0:
+            # must do a string comparison
+            lhs_value = lhs_resolved
+            rhs_value = rhs_resolved
+        else:
+            # can do a numeric comparison
+            lhs_value = lhs_expression.get_value(None, self._line)
+            rhs_value = rhs_expression.get_value(None, self._line)
+
+        print(f"Comparing {lhs_value} {self._operator} {rhs_value}")
+
+        if self._operator == "==":
+            return lhs_value == rhs_value
+        elif self._operator == "!=":
+            return lhs_value != rhs_value
+        elif self._operator == ">":
+            return lhs_value > rhs_value
+        elif self._operator == ">=":
+            return lhs_value >= rhs_value
+        elif self._operator == "<":
+            return lhs_value < rhs_value
+        elif self._operator == "<=":
+            return lhs_value <= rhs_value
+        else:
+            raise ValueError(f"Unknown operator {self._operator}")

--- a/src/bespokeasm/assembler/preprocessor/condition.py
+++ b/src/bespokeasm/assembler/preprocessor/condition.py
@@ -105,8 +105,8 @@ class IfPreprocessorCondition(PreprocessorCondition):
         raise ValueError("Cannot set parent of an IfPreprocessorCondition")
 
     def _evaluate_condition(self, preprocessor: Preprocessor) -> bool:
-        lhs_resolved = preprocessor.resolve_symbols(self._lhs_expression)
-        rhs_resolved = preprocessor.resolve_symbols(self._rhs_expression)
+        lhs_resolved = preprocessor.resolve_symbols(self._line, self._lhs_expression)
+        rhs_resolved = preprocessor.resolve_symbols(self._line, self._rhs_expression)
 
         lhs_expression: ExpressionNode = parse_expression(self._line, lhs_resolved)
         rhs_expression: ExpressionNode = parse_expression(self._line, rhs_resolved)

--- a/src/bespokeasm/assembler/preprocessor/condition.py
+++ b/src/bespokeasm/assembler/preprocessor/condition.py
@@ -19,6 +19,15 @@ PREPROCESSOR_CONDITION_IMPLIED_IF_PATTERN = re.compile(
     r"^(?:#if)\s+([\w\d_]+)\b"
 )
 
+PREPROCESSOR_CONDITION_ELIF_PATTERN = re.compile(
+    f"^(?:#elif)\\s+([\\w\\d_]+)\\s+(==|!=|>|>=|<|<=)\\s+"
+    f"(?:(?:\\\')(.+)(?:\\\')|(?:\\\")(.+)(?:\\\")|({INSTRUCTION_EXPRESSION_PATTERN}))"
+)
+
+PREPROCESSOR_CONDITION_IMPLIED_ELIF_PATTERN = re.compile(
+    r"^(?:#elif)\s+([\w\d_]+)\b"
+)
+
 PREPROCESSOR_CONDITION_IFDEF_PATTERN = re.compile(
     r"^(#ifdef|#ifndef)\s+([\w\d_]+)\b"
 )
@@ -72,6 +81,58 @@ class IfPreprocessorCondition(PreprocessorCondition):
         match = PREPROCESSOR_CONDITION_IF_PATTERN.match(line_str.strip())
         if match is None:
             match2 = PREPROCESSOR_CONDITION_IMPLIED_IF_PATTERN.match(line_str.strip())
+            if match2 is None:
+                raise ValueError(f"Invalid preprocessor condition at line: {line_str}")
+            self._lhs_expression = match2.group(1)
+            self._operator = "!="
+            self._rhs_expression = "0"
+        else:
+            self._lhs_expression = match.group(1)
+            self._operator = match.group(2)
+            self._rhs_expression = match.group(3) or match.group(4) or match.group(5)
+
+    def __repr__(self) -> str:
+        return f"PreprocessorCondition<#if {self._lhs_symbol} {self._operator} {self._rhs_expression}>"
+
+    def evaluate(self, preprocessor: Preprocessor) -> bool:
+        lhs_resolved = preprocessor.resolve_symbols(self._lhs_expression)
+        rhs_resolved = preprocessor.resolve_symbols(self._rhs_expression)
+
+        lhs_expression: ExpressionNode = parse_expression(self._line, lhs_resolved)
+        rhs_expression: ExpressionNode = parse_expression(self._line, rhs_resolved)
+
+        if len(lhs_expression.contained_labels()) > 0 or len(rhs_expression.contained_labels()) > 0:
+            # must do a string comparison
+            lhs_value = lhs_resolved
+            rhs_value = rhs_resolved
+        else:
+            # can do a numeric comparison
+            lhs_value = lhs_expression.get_value(None, self._line)
+            rhs_value = rhs_expression.get_value(None, self._line)
+
+        if self._operator == "==":
+            return lhs_value == rhs_value
+        elif self._operator == "!=":
+            return lhs_value != rhs_value
+        elif self._operator == ">":
+            return lhs_value > rhs_value
+        elif self._operator == ">=":
+            return lhs_value >= rhs_value
+        elif self._operator == "<":
+            return lhs_value < rhs_value
+        elif self._operator == "<=":
+            return lhs_value <= rhs_value
+        else:
+            raise ValueError(f"Unknown operator {self._operator}")
+
+
+class ElifPreprocessorCondition(DependentPreprocessorCondition):
+    def __init__(self, line_str: str, line: LineIdentifier):
+        super().__init__(line_str, line)
+
+        match = PREPROCESSOR_CONDITION_ELIF_PATTERN.match(line_str.strip())
+        if match is None:
+            match2 = PREPROCESSOR_CONDITION_IMPLIED_ELIF_PATTERN.match(line_str.strip())
             if match2 is None:
                 raise ValueError(f"Invalid preprocessor condition at line: {line_str}")
             self._lhs_expression = match2.group(1)

--- a/src/bespokeasm/assembler/preprocessor/condition_stack.py
+++ b/src/bespokeasm/assembler/preprocessor/condition_stack.py
@@ -18,7 +18,6 @@ class ConsitionStack:
             # this way the dependent chain is only ever 1-deep in the stack, making nested #if/#else/#endif
             # statements easier to handle.
             popped_condition = self._stack.pop()
-            # TODO: check if popped_condition is allowed to be the parent of this condition
             condition.parent = popped_condition
             self._stack.append(condition)
         else:

--- a/src/bespokeasm/assembler/preprocessor/condition_stack.py
+++ b/src/bespokeasm/assembler/preprocessor/condition_stack.py
@@ -1,6 +1,6 @@
 
 from bespokeasm.assembler.preprocessor.condition import \
-            PreprocessorCondition, DependentPreprocessorCondition, EndifPreprocessorCondition
+            PreprocessorCondition, EndifPreprocessorCondition
 from bespokeasm.assembler.preprocessor import Preprocessor
 
 
@@ -11,14 +11,14 @@ class ConsitionStack:
     def process_condition(self, condition: PreprocessorCondition):
         if isinstance(condition, EndifPreprocessorCondition):
             popped_consition = self._stack.pop()
-            if isinstance(popped_consition, DependentPreprocessorCondition):
+            if popped_consition.is_dependent:
                 pass
-        elif isinstance(condition, DependentPreprocessorCondition):
+        elif condition.is_dependent:
             # a dependent condition pops the current condition and makes it the parent to the new condition.
             # this way the dependent chain is only ever 1-deep in the stack, making nested #if/#else/#endif
             # statements easier to handle.
             popped_condition = self._stack.pop()
-            # TODO: check if popped_condition is allowed to be the parent of tihs condition
+            # TODO: check if popped_condition is allowed to be the parent of this condition
             condition.parent = popped_condition
             self._stack.append(condition)
         else:

--- a/src/bespokeasm/assembler/preprocessor/condition_stack.py
+++ b/src/bespokeasm/assembler/preprocessor/condition_stack.py
@@ -1,0 +1,30 @@
+
+from bespokeasm.assembler.preprocessor.condition import \
+            PreprocessorCondition, DependentPreprocessorCondition, EndifPreprocessorCondition
+from bespokeasm.assembler.preprocessor import Preprocessor
+
+
+class ConsitionStack:
+    def __init__(self):
+        self._stack: list[PreprocessorCondition] = []
+
+    def process_condition(self, condition: PreprocessorCondition):
+        if isinstance(condition, EndifPreprocessorCondition):
+            popped_consition = self._stack.pop()
+            if isinstance(popped_consition, DependentPreprocessorCondition):
+                pass
+        elif isinstance(condition, DependentPreprocessorCondition):
+            # a dependent condition pops the current condition and makes it the parent to the new condition.
+            # this way the dependent chain is only ever 1-deep in the stack, making nested #if/#else/#endif
+            # statements easier to handle.
+            popped_condition = self._stack.pop()
+            # TODO: check if popped_condition is allowed to be the parent of tihs condition
+            condition.parent = popped_condition
+            self._stack.append(condition)
+        else:
+            self._stack.append(condition)
+
+    def currently_active(self, preprocessor: Preprocessor) -> bool:
+        if len(self._stack) == 0:
+            return True
+        return self._stack[-1].evaluate(preprocessor)

--- a/src/bespokeasm/assembler/preprocessor/condition_stack.py
+++ b/src/bespokeasm/assembler/preprocessor/condition_stack.py
@@ -4,7 +4,7 @@ from bespokeasm.assembler.preprocessor.condition import \
 from bespokeasm.assembler.preprocessor import Preprocessor
 
 
-class ConsitionStack:
+class ConditionStack:
     def __init__(self):
         self._stack: list[PreprocessorCondition] = []
 

--- a/src/bespokeasm/assembler/preprocessor/symbol.py
+++ b/src/bespokeasm/assembler/preprocessor/symbol.py
@@ -1,0 +1,30 @@
+from bespokeasm.utilities import is_string_numeric
+
+
+class PreprocessorSymbol:
+    def __init__(self, name: str, value: str):
+        self.name = name
+        self.value = value
+
+    def __repr__(self) -> str:
+        return f"PrerocessorSymbol({self.name} = {self.value})"
+
+    def __eq__(self, other) -> bool:
+        return self.name == other.name and self.value == other.value
+
+    def __hash__(self) -> int:
+        return hash((self.name, self.value))
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def value(self) -> str:
+        return self._value
+
+    @property
+    def is_value_numeric(self) -> bool:
+        if self.value is None:
+            return False
+        return is_string_numeric(self.value)

--- a/src/bespokeasm/assembler/preprocessor/symbol.py
+++ b/src/bespokeasm/assembler/preprocessor/symbol.py
@@ -1,10 +1,12 @@
-from bespokeasm.utilities import is_string_numeric
+from functools import cached_property
+
+from bespokeasm.utilities import is_string_numeric, parse_numeric_string
 
 
 class PreprocessorSymbol:
     def __init__(self, name: str, value: str):
-        self.name = name
-        self.value = value
+        self._name = name
+        self._value = value
 
     def __repr__(self) -> str:
         return f"PrerocessorSymbol({self.name} = {self.value})"
@@ -23,7 +25,14 @@ class PreprocessorSymbol:
     def value(self) -> str:
         return self._value
 
-    @property
+    @cached_property
+    def value_numeric(self) -> int:
+        '''Returns the numeric value of the symbol, or None if the value is not numeric'''
+        if self.value is None or not self.is_value_numeric:
+            return None
+        return parse_numeric_string(self.value)
+
+    @cached_property
     def is_value_numeric(self) -> bool:
         if self.value is None:
             return False

--- a/src/bespokeasm/assembler/preprocessor/symbol.py
+++ b/src/bespokeasm/assembler/preprocessor/symbol.py
@@ -1,12 +1,17 @@
 from functools import cached_property
 
 from bespokeasm.utilities import is_string_numeric, parse_numeric_string
+from bespokeasm.assembler.line_identifier import LineIdentifier
+
+
+SYMBOL_PATTERN = r"[\w_][\w\d_]+"
 
 
 class PreprocessorSymbol:
-    def __init__(self, name: str, value: str):
+    def __init__(self, name: str, value: str, line_id: LineIdentifier = None):
         self._name = name
-        self._value = value
+        self._value = value if value is not None else ''
+        self._line_id = line_id
 
     def __repr__(self) -> str:
         return f"PrerocessorSymbol({self.name} = {self.value})"
@@ -24,6 +29,10 @@ class PreprocessorSymbol:
     @property
     def value(self) -> str:
         return self._value
+
+    @property
+    def created_line_id(self) -> LineIdentifier:
+        return self._line_id
 
     @cached_property
     def value_numeric(self) -> int:

--- a/src/bespokeasm/assembler/pretty_printer/listing.py
+++ b/src/bespokeasm/assembler/pretty_printer/listing.py
@@ -4,6 +4,7 @@ import math
 from bespokeasm.assembler.line_object import LineObject, LineWithBytes
 from bespokeasm.assembler.line_object.label_line import LabelLine
 from bespokeasm.assembler.line_object.directive_line import SetMemoryZoneLine
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.pretty_printer import PrettyPrinterBase
 from bespokeasm.assembler.line_identifier import LineIdentifier
@@ -132,7 +133,9 @@ class ListingPrettyPrinter(PrettyPrinterBase):
         output.write('| ')
 
         # write the instruction
-        if not isinstance(lobj, LabelLine) and not isinstance(lobj, SetMemoryZoneLine):
+        if not isinstance(lobj, LabelLine) \
+                and not isinstance(lobj, SetMemoryZoneLine) \
+                and not isinstance(lobj, PreprocessorLine):
             instruction_str = ' '*ListingPrettyPrinter.INSTRUCTION_INDENT + lobj.instruction
         else:
             instruction_str = lobj.instruction

--- a/src/bespokeasm/assembler/pretty_printer/listing.py
+++ b/src/bespokeasm/assembler/pretty_printer/listing.py
@@ -1,5 +1,6 @@
 import io
 import math
+import sys
 
 from bespokeasm.assembler.line_object import LineObject, LineWithBytes
 from bespokeasm.assembler.line_object.label_line import LabelLine
@@ -127,7 +128,10 @@ class ListingPrettyPrinter(PrettyPrinterBase):
 
         # write the machine code
         if line_bytes is not None:
-            output.write(line_bytes[0])
+            try:
+                output.write(line_bytes[0])
+            except IndexError:
+                sys.exit(f'ERROR - internal: line_bytes is empty for line {lobj} at {lobj.line_id}')
         else:
             output.write(' ' * self._bytes_per_line * 3)
         output.write('| ')

--- a/src/bespokeasm/configgen/sublime/resources/sublime-color-scheme.json
+++ b/src/bespokeasm/configgen/sublime/resources/sublime-color-scheme.json
@@ -26,6 +26,11 @@
             "foreground": "#fffd80"
         },
         {
+            "name": "Numbers - Character",
+            "scope": "constant.numeric.character",
+            "foreground": "#FFE880"
+        },
+        {
             "name": "Labels",
             "scope": "variable.other.label",
             "foreground": "#278ed8"

--- a/src/bespokeasm/configgen/sublime/resources/sublime-syntax.yaml
+++ b/src/bespokeasm/configgen/sublime/resources/sublime-syntax.yaml
@@ -83,6 +83,12 @@ contexts:
       scope: constant.numeric.integer.binary
     - match: (?<!\w)(?:\d+)\b
       scope: constant.numeric.integer.decimal
+    - match: (?:\'.\')
+      scope: constant.numeric.character
+
+  comparison_operators:
+    - match: (?:==|!=|>|>=|<|<=)
+      scope: keyword.operator.logical
 
   numerical_expressions:
     - include: numbers
@@ -92,6 +98,7 @@ contexts:
       scope: keyword.operator.arithmetic
     - match: "[\\&\\|\\^]{1}"
       scope: keyword.operator.logical
+    - include: comparison_operators
     - match: (?:>>|<<)
       scope: keyword.operator.bitwise
     - match: \b(?:##EXPRESSION_FUNCTIONS##)\b

--- a/src/bespokeasm/configgen/vscode/resources/tmGrammar.json
+++ b/src/bespokeasm/configgen/vscode/resources/tmGrammar.json
@@ -108,6 +108,10 @@
                 {
                     "name": "constant.numeric.integer.decimal",
                     "match": "(?<!\\w)(?:\\d+)\\b"
+                },
+                {
+                    "name": "constant.numeric.character",
+                    "match": "(?<!\\w)(?:\\'.\\')\\b"
                 }
             ]
         },
@@ -128,6 +132,10 @@
                 {
                     "name": "keyword.operator.word",
                     "match": "\\b(?:##EXPRESSION_FUNCTIONS##)\\b"
+                },
+                {
+                    "name": "keyword.operator.comparison",
+                    "match": "(?:==|!=|>|>=|<|<=)"
                 }
             ]
         },

--- a/src/bespokeasm/configgen/vscode/resources/tmTheme.xml
+++ b/src/bespokeasm/configgen/vscode/resources/tmTheme.xml
@@ -54,6 +54,17 @@
         </dict>
         <dict>
             <key>name</key>
+            <string>Numbers - Character</string>
+            <key>scope</key>
+            <string>constant.numeric.character</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#FFE880</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
             <string>Labels</string>
             <key>scope</key>
             <string>variable.other.label</string>

--- a/test/config_files/test_compilation_control.yaml
+++ b/test/config_files/test_compilation_control.yaml
@@ -1,0 +1,386 @@
+description: Test Compilation Control
+general :
+  address_size: 16
+  endian: little
+  origin: 0x0100
+  identifier:
+    name: compilation-control-test
+    version: "0.2.0"
+  registers:
+    - a
+    - i
+    - j
+    - sp
+    - ij
+    - mar
+  min_version: "0.3.4"
+predefined:
+operand_sets:
+  8_bit_source:
+    operand_values:
+      a:
+        type: register
+        register: a
+        bytecode:
+          value: 0
+          size: 3
+      i:
+        type: register
+        register: i
+        bytecode:
+          value: 2
+          size: 3
+      j:
+        type: register
+        register: j
+        bytecode:
+          value: 3
+          size: 3
+      ij:
+        type: indirect_register
+        register: ij
+        bytecode:
+          value: 4
+          size: 3
+        offset:
+          max: 127
+          min: -128
+          size: 8
+          byte_align: true
+      sp:
+        type: indirect_register
+        register: sp
+        bytecode:
+          value: 5
+          size: 3
+        offset:
+          max: 127
+          min: -128
+          size: 8
+          byte_align: true
+      indirect_addr:
+        type: indirect_numeric
+        bytecode:
+          value: 6
+          size: 3
+        argument:
+          size: 16
+          byte_align: true
+      direct_value:
+        type: numeric
+        bytecode:
+          value: 7
+          size: 3
+        argument:
+          size: 8
+          byte_align: true
+  8_bit_destination:
+    operand_values:
+      a:
+        type: register
+        register: a
+        bytecode:
+          value: 0
+          size: 3
+      i:
+        type: register
+        register: i
+        bytecode:
+          value: 2
+          size: 3
+      j:
+        type: register
+        register: j
+        bytecode:
+          value: 3
+          size: 3
+      ij:
+        type: indirect_register
+        register: ij
+        bytecode:
+          value: 4
+          size: 3
+        offset:
+          max: 127
+          min: -128
+          size: 8
+          byte_align: true
+      sp:
+        type: indirect_register
+        register: sp
+        bytecode:
+          value: 5
+          size: 3
+        offset:
+          max: 127
+          min: -128
+          size: 8
+          byte_align: true
+      indirect_addr:
+        type: indirect_numeric
+        bytecode:
+          value: 6
+          size: 3
+        argument:
+          size: 16
+          byte_align: true
+  int8:
+    operand_values:
+      int8:
+        type: numeric
+        argument:
+          size: 8
+          byte_align: true
+  int16:
+    operand_values:
+      int16:
+        type: numeric
+        argument:
+          size: 16
+          byte_align: true
+  stack_pointer:
+    operand_values:
+      sp:
+        type: indirect_register
+        register: sp
+        bytecode:
+          value: 5
+          size: 3
+        offset:
+          max: 127
+          min: -128
+          size: 8
+          byte_align: true
+instructions:
+  push:
+    operands:
+      count: 1
+      operand_sets:
+        list:
+          - 8_bit_source
+    bytecode:
+      value: 1
+      size: 5
+  pop:
+    operands:
+      count: 1
+      operand_sets:
+        list:
+          - 8_bit_destination
+    bytecode:
+      value: 0
+      size: 5
+  mov:
+    operands:
+      count: 2
+      operand_sets:
+        list:
+          - 8_bit_destination
+          - 8_bit_source
+    bytecode:
+      value: 1
+      size: 2
+  add:
+    bytecode:
+      value: 2
+      size: 5
+    operands:
+      count: 1
+      operand_sets:
+        list:
+          - 8_bit_source
+  addc:
+    bytecode:
+      value: 3
+      size: 5
+    operands:
+      count: 1
+      operand_sets:
+        list:
+          - 8_bit_source
+macros:
+  push2:
+    - operands:
+        count: 1
+        specific_operands:
+          immediate:
+            list:
+              uint16:
+                type: numeric
+                argument:
+                  size: 16
+                  byte_align: true
+      instructions:
+        - "push ((@ARG(0)) >> 8)"
+        - "push ((@ARG(0)) & 0x00FF)"
+    - operands:
+        count: 1
+        specific_operands:
+          ij_reg:
+            list:
+              ij:
+                type: indirect_register
+                register: ij
+                offset:
+                  max: 127
+                  min: -128
+                  size: 8
+                  byte_align: true
+      instructions:
+        - "push [@REG(0) + (@ARG(0)+1)]"
+        - "push [@REG(0) + (@ARG(0))]"
+    - operands:
+        count: 1
+        specific_operands:
+          stack_pointer:
+            list:
+              sp:
+                type: indirect_register
+                register: sp
+                offset:
+                  max: 127
+                  min: -128
+                  size: 8
+                  byte_align: true
+      instructions:
+        - "push [@REG(0) + (@ARG(0)+1)]"
+        - "push [@REG(0) + (@ARG(0)+1)]"
+  mov2:
+    - operands:
+        count: 2
+        specific_operands:
+          iaddr1_iaddr2:
+            list:
+              iaddr1:
+                type: indirect_numeric
+                argument:
+                  size: 16
+                  byte_align: true
+              iaddr2:
+                type: indirect_numeric
+                argument:
+                  size: 16
+                  byte_align: true
+      instructions:
+        - "mov [@ARG(0)],[@ARG(1)]"
+        - "mov [@ARG(0) + 1],[@ARG(1) + 1]"
+    - operands:
+        count: 2
+        specific_operands:
+          iaddr1_iaddr2:
+            list:
+              iaddr1:
+                type: indirect_numeric
+                argument:
+                  size: 16
+                  byte_align: true
+              iaddr2:
+                type: numeric
+                argument:
+                  size: 16
+                  byte_align: true
+      instructions:
+        - "mov [@ARG(0)],BYTE0(@ARG(1))"
+        - "mov [@ARG(0) + 1],BYTE1(@ARG(1))"
+  add16:
+    - operands:
+        count: 2
+        specific_operands:
+          iaddr1_immediate:
+            list:
+              iaddr_x:
+                type: indirect_numeric
+                argument:
+                  size: 16
+                  byte_align: true
+              immediate_y:
+                type: numeric
+                argument:
+                  size: 16
+                  byte_align: true
+      instructions:
+        - "mov a,[@ARG(0)]"
+        - "add (@ARG(1) & $00FF)"
+        - "mov [@ARG(0)],a"
+        - "mov a,[@ARG(0)+1]"
+        - "addc ((@ARG(1) & $FF00) >> 8)"
+        - "mov [@ARG(0)+1],a"
+    - operands:
+        count: 2
+        specific_operands:
+          iaddr1_iaddr2:
+            list:
+              iaddr_x:
+                type: indirect_numeric
+                argument:
+                  size: 16
+                  byte_align: true
+              iaddr_y:
+                type: indirect_numeric
+                argument:
+                  size: 16
+                  byte_align: true
+      instructions:
+        - "mov a,[@ARG(0)]"
+        - "add [@ARG(1)]"
+        - "mov [@ARG(0)],a"
+        - "mov a,[@ARG(0)+1]"
+        - "addc [@ARG(1)+1]"
+        - "mov [@ARG(0)+1],a"
+  swap:
+    - operands:
+        count: 2
+        operand_sets:
+          list:
+            - 8_bit_destination
+            - 8_bit_destination
+          disallowed_pairs:
+            - [a, sp]
+            - [i, sp]
+            - [j, sp]
+            - [ij, sp]
+            - [sp, sp]
+            - [indirect_addr, sp]
+            - [sp, a]
+            - [sp, i]
+            - [sp, j]
+            - [sp, ij]
+            - [sp, indirect_addr]
+      instructions:
+        - "push @OP(0)"
+        - "mov @OP(0),@OP(1)"
+        - "pop @OP(1)"
+    - operands:
+        count: 2
+        operand_sets:
+          list:
+            - 8_bit_destination
+            - stack_pointer
+          disallowed_pairs:
+            - [sp, sp]
+      instructions:
+        - "push @OP(0)"
+        - "mov @OP(0),[@REG(1) + (@ARG(1)+1)]"
+        - "pop [@REG(1) + (@ARG(1)+1)]"
+    - operands:
+        count: 2
+        operand_sets:
+          list:
+            - stack_pointer
+            - 8_bit_destination
+          disallowed_pairs:
+            - [sp, sp]
+      instructions:
+        - "push @OP(0)"
+        - "mov [@REG(0) + (@ARG(0)+1)],@OP(1)"
+        - "pop @OP(1)"
+    - operands:
+        count: 2
+        operand_sets:
+          list:
+            - stack_pointer
+            - stack_pointer
+      instructions:
+        - "push @OP(0)"
+        - "mov [@REG(0) + (@ARG(0)+1)],[@REG(1) + (@ARG(1)+1)]"
+        - "pop [@REG(1) + (@ARG(1)+1)]"

--- a/test/config_files/test_compilation_control.yaml
+++ b/test/config_files/test_compilation_control.yaml
@@ -13,7 +13,7 @@ general :
     - sp
     - ij
     - mar
-  min_version: "0.3.4"
+  min_version: "0.4.0"
 predefined:
 operand_sets:
   8_bit_source:

--- a/test/test_code/test_compilation_control.asm
+++ b/test/test_code/test_compilation_control.asm
@@ -16,10 +16,17 @@ start:
     pop i
 #else
     pop j
-#endif
-
-#ifdef SYMBOL3
+#ifdef SYMBOL3      ; nested #ifdef
     mov a, 0
 #else
     mov a, 1
+#endif
+#endif
+
+#if SYMBOL1 == 2
+    push a
+#elif SYMBOL1 == 1
+    push i
+#else
+    push j
 #endif

--- a/test/test_code/test_compilation_control.asm
+++ b/test/test_code/test_compilation_control.asm
@@ -1,0 +1,25 @@
+#require "compilation-control-test >= 0.2.0"
+
+#define SYMBOL1 1
+#define SYMBOL2 0
+#define SYMBOL3
+
+start:
+    push a
+#if SYMBOL1
+    push i
+#else
+    push j
+#endif
+
+#if SYMBOL2
+    pop i
+#else
+    pop j
+#endif
+
+#ifdef SYMBOL3
+    mov a, 0
+#else
+    mov a, 1
+#endif

--- a/test/test_code/test_compilation_control.asm
+++ b/test/test_code/test_compilation_control.asm
@@ -17,9 +17,9 @@ start:
 #else
     pop j
 #ifdef SYMBOL3      ; nested #ifdef
-    mov a, 0
+    mov a, SYMBOL2
 #else
-    mov a, 1
+    mov a, SYMBOL1
 #endif
 #endif
 

--- a/test/test_configgen.py
+++ b/test/test_configgen.py
@@ -242,7 +242,7 @@ class TestConfigurationGeneration(unittest.TestCase):
                 item_match_str = item['match']
         self._assert_grouped_item_list(
             item_match_str,
-            ['include', 'require', 'create_memzone'],
+            ['include', 'require', 'create_memzone', 'define', 'if', 'elif', 'else', 'endif', 'ifdef', 'ifndef'],
             'data type directives'
         )
         self.assertIsFile(os.path.join(test_tmp_dir, 'bespokeasm-test.sublime-color-scheme'))
@@ -323,7 +323,7 @@ class TestConfigurationGeneration(unittest.TestCase):
                 item_match_str = item['match']
         self._assert_grouped_item_list(
             item_match_str,
-            ['include', 'require', 'create_memzone'],
+            ['include', 'require', 'create_memzone', 'define', 'if', 'elif', 'else', 'endif', 'ifdef', 'ifndef'],
             'data type directives'
         )
         self.assertIsFile(os.path.join(test_tmp_dir, 'tester-assembly.sublime-color-scheme'))

--- a/test/test_instruction_parsing.py
+++ b/test/test_instruction_parsing.py
@@ -11,6 +11,7 @@ from bespokeasm.assembler.line_object.instruction_line import InstructionLine
 from bespokeasm.assembler.line_object.label_line import LabelLine
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
+from bespokeasm.assembler.preprocessor import Preprocessor
 
 
 class TestInstructionParsing(unittest.TestCase):
@@ -296,6 +297,8 @@ class TestInstructionParsing(unittest.TestCase):
             )
 
         lineid = LineIdentifier(42, 'test_label_parsing')
+        preprocessor = Preprocessor()
+
         l1: LineObject = LineOjectFactory.parse_line(
             lineid,
             "LABEL = %00001111",
@@ -303,6 +306,8 @@ class TestInstructionParsing(unittest.TestCase):
             TestInstructionParsing.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )[0]
         self.assertIsInstance(l1, LabelLine)
         self.assertTrue(l1.is_constant, )
@@ -315,6 +320,8 @@ class TestInstructionParsing(unittest.TestCase):
             TestInstructionParsing.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )[0]
         l2.set_start_address(42)
         l2.label_scope = TestInstructionParsing.label_values
@@ -329,6 +336,8 @@ class TestInstructionParsing(unittest.TestCase):
             TestInstructionParsing.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )[0]
         l3.set_start_address(42)
         l3.label_scope = TestInstructionParsing.label_values

--- a/test/test_instruction_parsing.py
+++ b/test/test_instruction_parsing.py
@@ -12,6 +12,7 @@ from bespokeasm.assembler.line_object.label_line import LabelLine
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.preprocessor import Preprocessor
+from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
 
 
 class TestInstructionParsing(unittest.TestCase):
@@ -307,6 +308,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )[0]
         self.assertIsInstance(l1, LabelLine)
@@ -321,6 +323,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )[0]
         l2.set_start_address(42)
@@ -337,6 +340,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )[0]
         l3.set_start_address(42)

--- a/test/test_instruction_parsing.py
+++ b/test/test_instruction_parsing.py
@@ -12,7 +12,7 @@ from bespokeasm.assembler.line_object.label_line import LabelLine
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.preprocessor import Preprocessor
-from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+from bespokeasm.assembler.preprocessor.condition_stack import ConditionStack
 
 
 class TestInstructionParsing(unittest.TestCase):
@@ -308,7 +308,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )[0]
         self.assertIsInstance(l1, LabelLine)
@@ -323,7 +323,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )[0]
         l2.set_start_address(42)
@@ -340,7 +340,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )[0]
         l3.set_start_address(42)

--- a/test/test_label_scope.py
+++ b/test/test_label_scope.py
@@ -12,6 +12,7 @@ from bespokeasm.assembler.label_scope import LabelScope, LabelScopeType, GlobalL
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.assembler.preprocessor import Preprocessor
 
 
 class TestLabelScope(unittest.TestCase):
@@ -96,6 +97,7 @@ class TestLabelScope(unittest.TestCase):
             isa_model.default_origin,
             isa_model.predefined_memory_zones
         )
+        preprocessor = Preprocessor()
 
         with pkg_resources.path(test_code, 'test_line_object_scope_assignment.asm') as asm_fp:
             asm_obj = AssemblyFile(asm_fp, label_scope)
@@ -105,6 +107,7 @@ class TestLabelScope(unittest.TestCase):
                 isa_model,
                 [],
                 memzone_manager,
+                preprocessor,
                 3,
             )
         except SystemExit:

--- a/test/test_label_scope.py
+++ b/test/test_label_scope.py
@@ -116,7 +116,7 @@ class TestLabelScope(unittest.TestCase):
             raise
 
         # ensure file was assembled as expected
-        self.assertEqual(len(line_objs), 12, '12 code lines')
+        self.assertEqual(len(line_objs), 13, '13 code lines')
         # the memzone manager should have created memzone
         self.assertIsNotNone(memzone_manager.zone('zone1'), 'zone1 memory zone should exist')
         # label scope should have 1 file and 3 local scopes assigned to lines
@@ -128,21 +128,22 @@ class TestLabelScope(unittest.TestCase):
         self.assertEqual(len(label_scope_dict[LabelScopeType.LOCAL]), 3, '3 local label scopes')
         # validate each line's label scope
         self.assertEqual(line_objs[0].label_scope.type, LabelScopeType.FILE)
-        self.assertEqual(line_objs[1].label_scope.type, LabelScopeType.LOCAL)
-        self.assertEqual(line_objs[1].label_scope.reference, 'label1')
+        self.assertEqual(line_objs[1].label_scope.type, LabelScopeType.FILE)
         self.assertEqual(line_objs[2].label_scope.type, LabelScopeType.LOCAL)
         self.assertEqual(line_objs[2].label_scope.reference, 'label1')
         self.assertEqual(line_objs[3].label_scope.type, LabelScopeType.LOCAL)
         self.assertEqual(line_objs[3].label_scope.reference, 'label1')
         self.assertEqual(line_objs[4].label_scope.type, LabelScopeType.LOCAL)
-        self.assertEqual(line_objs[4].label_scope.reference, 'label2')
+        self.assertEqual(line_objs[4].label_scope.reference, 'label1')
         self.assertEqual(line_objs[5].label_scope.type, LabelScopeType.LOCAL)
         self.assertEqual(line_objs[5].label_scope.reference, 'label2')
-        self.assertEqual(line_objs[6].label_scope.type, LabelScopeType.FILE, '.org should reset label scope to FILE')
-        self.assertEqual(line_objs[7].label_scope.type, LabelScopeType.FILE)
-        self.assertEqual(line_objs[8].label_scope.type, LabelScopeType.LOCAL)
-        self.assertEqual(line_objs[8].label_scope.reference, 'label3')
+        self.assertEqual(line_objs[6].label_scope.type, LabelScopeType.LOCAL)
+        self.assertEqual(line_objs[6].label_scope.reference, 'label2')
+        self.assertEqual(line_objs[7].label_scope.type, LabelScopeType.FILE, '.org should reset label scope to FILE')
+        self.assertEqual(line_objs[8].label_scope.type, LabelScopeType.FILE)
         self.assertEqual(line_objs[9].label_scope.type, LabelScopeType.LOCAL)
         self.assertEqual(line_objs[9].label_scope.reference, 'label3')
-        self.assertEqual(line_objs[10].label_scope.type, LabelScopeType.FILE, '.memzone should reset label scope to FILE')
-        self.assertEqual(line_objs[11].label_scope.type, LabelScopeType.FILE)
+        self.assertEqual(line_objs[10].label_scope.type, LabelScopeType.LOCAL)
+        self.assertEqual(line_objs[10].label_scope.reference, 'label3')
+        self.assertEqual(line_objs[11].label_scope.type, LabelScopeType.FILE, '.memzone should reset label scope to FILE')
+        self.assertEqual(line_objs[12].label_scope.type, LabelScopeType.FILE)

--- a/test/test_line_objects.py
+++ b/test/test_line_objects.py
@@ -154,6 +154,15 @@ class TestLineObject(unittest.TestCase):
         self.assertEqual(d11.byte_size, 7, 'byte string has 7 bytes')
         self.assertEqual(d11.get_bytes(), bytearray(d11_values), 'character string matches')
 
+        # test expressions in .byte lists
+        d12 = DataLine.factory(38, '.byte ((PSAV+1) & 0FFH), $22+$44, 1<<4', 'escape reality', 'big', memzone)
+        label_values.set_label_value('PSAV', 0x1234, LineIdentifier(1, 'test_d12'))
+        d12.label_scope = label_values
+        d12.generate_bytes()
+        self.assertIsInstance(d12, DataLine)
+        self.assertEqual(d12.byte_size, 3, 'byte string has 3 bytes')
+        self.assertEqual(d12.get_bytes(), bytearray([0x35, 0x66, 0x10]), 'byte array matches')
+
         with self.assertRaises(SystemExit, msg='this instruction should fail'):
             DataLine.factory(42, ' .cstr 0x42', 'bad cstr usage', 'big', memzone)
 

--- a/test/test_line_objects.py
+++ b/test/test_line_objects.py
@@ -12,6 +12,7 @@ from bespokeasm.assembler.line_object.directive_line import AddressOrgLine
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.preprocessor import Preprocessor
 
 from test import config_files
 
@@ -238,6 +239,8 @@ class TestLineObject(unittest.TestCase):
 
         lineid = LineIdentifier(123, 'test_label_line_with_instruction')
 
+        preprocessor = Preprocessor()
+
         # test data line on label line
         objs1: list[LineObject] = LineOjectFactory.parse_line(
             lineid,
@@ -246,6 +249,8 @@ class TestLineObject(unittest.TestCase):
             label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(objs1), 2, 'there should be two instructions')
         self.assertIsInstance(objs1[0], LabelLine, 'the first line object should be a label')
@@ -264,6 +269,8 @@ class TestLineObject(unittest.TestCase):
             label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(objs2), 2, 'there should be two instructions')
         self.assertIsInstance(objs2[0], LabelLine, 'the first line object should be a label')
@@ -282,6 +289,8 @@ class TestLineObject(unittest.TestCase):
             label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(objs3), 1, 'there should be two instructions')
         self.assertIsInstance(objs3[0], LabelLine, 'the first line object should be a label')
@@ -546,6 +555,8 @@ class TestLineObject(unittest.TestCase):
             label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            Preprocessor(),
+            0,
         )
         self.assertEqual(len(lo1), 1, 'only one instruction to parse')
         print(lo1[0])
@@ -564,6 +575,7 @@ class TestLineObject(unittest.TestCase):
             )
 
         lineid = LineIdentifier(55, 'test_compound_instruction_line')
+        preprocessor = Preprocessor()
 
         lol1 = LineOjectFactory.parse_line(
             lineid,
@@ -572,6 +584,8 @@ class TestLineObject(unittest.TestCase):
             TestLineObject.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(lol1), 2, 'There should be two parsed instructions')
         self.assertIsInstance(lol1[0], LabelLine)
@@ -587,6 +601,8 @@ class TestLineObject(unittest.TestCase):
             TestLineObject.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(lol2), 3, 'There should be 3 parsed instructions')
         self.assertIsInstance(lol2[0], AddressOrgLine)
@@ -605,6 +621,8 @@ class TestLineObject(unittest.TestCase):
             TestLineObject.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(lol3), 2, 'There should be 2 parsed instructions')
         self.assertIsInstance(lol3[0], InstructionLine)
@@ -619,6 +637,8 @@ class TestLineObject(unittest.TestCase):
             TestLineObject.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(lol4), 2, 'There should be 2 parsed instructions')
         self.assertIsInstance(lol4[0], InstructionLine)
@@ -635,6 +655,8 @@ class TestLineObject(unittest.TestCase):
             TestLineObject.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(lol4), 1, 'There should be 2 parsed instructions')
         self.assertIsInstance(lol4[0], InstructionLine)
@@ -646,6 +668,8 @@ class TestLineObject(unittest.TestCase):
             TestLineObject.label_values,
             memzone_mngr.global_zone,
             memzone_mngr,
+            preprocessor,
+            0,
         )
         self.assertEqual(len(lol5), 2, 'There should be 2 parsed instructions')
         self.assertIsInstance(lol5[0], LabelLine)
@@ -660,6 +684,8 @@ class TestLineObject(unittest.TestCase):
                     TestLineObject.label_values,
                     memzone_mngr.global_zone,
                     memzone_mngr,
+                    preprocessor,
+                    0,
                 )
 
     def test_unknown_instruction(self):
@@ -681,6 +707,8 @@ class TestLineObject(unittest.TestCase):
                     TestLineObject.label_values,
                     memzone_mngr.global_zone,
                     memzone_mngr,
+                    Preprocessor(),
+                    0,
                 )
 
 

--- a/test/test_line_objects.py
+++ b/test/test_line_objects.py
@@ -13,7 +13,7 @@ from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.preprocessor import Preprocessor
-from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+from bespokeasm.assembler.preprocessor.condition_stack import ConditionStack
 
 from test import config_files
 
@@ -260,7 +260,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(objs1), 2, 'there should be two instructions')
@@ -281,7 +281,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(objs2), 2, 'there should be two instructions')
@@ -302,7 +302,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(objs3), 1, 'there should be two instructions')
@@ -569,7 +569,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             Preprocessor(),
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(lo1), 1, 'only one instruction to parse')
@@ -599,7 +599,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(lol1), 2, 'There should be two parsed instructions')
@@ -617,7 +617,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(lol2), 3, 'There should be 3 parsed instructions')
@@ -638,7 +638,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(lol3), 2, 'There should be 2 parsed instructions')
@@ -655,7 +655,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(lol4), 2, 'There should be 2 parsed instructions')
@@ -674,7 +674,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(lol4), 1, 'There should be 2 parsed instructions')
@@ -688,7 +688,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )
         self.assertEqual(len(lol5), 2, 'There should be 2 parsed instructions')
@@ -705,7 +705,7 @@ class TestLineObject(unittest.TestCase):
                     memzone_mngr.global_zone,
                     memzone_mngr,
                     preprocessor,
-                    ConsitionStack(),
+                    ConditionStack(),
                     0,
                 )
 
@@ -729,7 +729,7 @@ class TestLineObject(unittest.TestCase):
                     memzone_mngr.global_zone,
                     memzone_mngr,
                     Preprocessor(),
-                    ConsitionStack(),
+                    ConditionStack(),
                     0,
                 )
 

--- a/test/test_line_objects.py
+++ b/test/test_line_objects.py
@@ -13,6 +13,7 @@ from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.preprocessor import Preprocessor
+from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
 
 from test import config_files
 
@@ -250,6 +251,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(objs1), 2, 'there should be two instructions')
@@ -270,6 +272,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(objs2), 2, 'there should be two instructions')
@@ -290,6 +293,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(objs3), 1, 'there should be two instructions')
@@ -556,6 +560,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             Preprocessor(),
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(lo1), 1, 'only one instruction to parse')
@@ -585,6 +590,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(lol1), 2, 'There should be two parsed instructions')
@@ -602,6 +608,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(lol2), 3, 'There should be 3 parsed instructions')
@@ -622,6 +629,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(lol3), 2, 'There should be 2 parsed instructions')
@@ -638,6 +646,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(lol4), 2, 'There should be 2 parsed instructions')
@@ -656,6 +665,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(lol4), 1, 'There should be 2 parsed instructions')
@@ -669,6 +679,7 @@ class TestLineObject(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
+            ConsitionStack(),
             0,
         )
         self.assertEqual(len(lol5), 2, 'There should be 2 parsed instructions')
@@ -685,6 +696,7 @@ class TestLineObject(unittest.TestCase):
                     memzone_mngr.global_zone,
                     memzone_mngr,
                     preprocessor,
+                    ConsitionStack(),
                     0,
                 )
 
@@ -708,6 +720,7 @@ class TestLineObject(unittest.TestCase):
                     memzone_mngr.global_zone,
                     memzone_mngr,
                     Preprocessor(),
+                    ConsitionStack(),
                     0,
                 )
 

--- a/test/test_memory_zones.py
+++ b/test/test_memory_zones.py
@@ -9,6 +9,7 @@ from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.label_scope import GlobalLabelScope
 from bespokeasm.assembler.assembly_file import AssemblyFile
+from bespokeasm.assembler.preprocessor import Preprocessor
 
 
 class TestMemoryZones(unittest.TestCase):
@@ -29,6 +30,7 @@ class TestMemoryZones(unittest.TestCase):
             isa_model.default_origin,
             isa_model.predefined_memory_zones
         )
+        preprocessor = Preprocessor()
         self.assertEqual(memzone_manager.global_zone.start, 0x0100, 'global zone starts at $0100')
         self.assertEqual(memzone_manager.global_zone.end, 0xDFFF, 'global zone ends at $DFFF')
 
@@ -39,6 +41,7 @@ class TestMemoryZones(unittest.TestCase):
                 isa_model,
                 [],
                 memzone_manager,
+                preprocessor,
                 3,
             )
 

--- a/test/test_memory_zones.py
+++ b/test/test_memory_zones.py
@@ -45,7 +45,7 @@ class TestMemoryZones(unittest.TestCase):
                 3,
             )
 
-        self.assertEqual(len(line_objs), 9, '9 code lines')
+        self.assertEqual(len(line_objs), 10, '10 code lines')
         self.assertIsNotNone(memzone_manager.zone('variables'), 'variables memory zone should exist')
         self.assertEqual(memzone_manager.zone('variables').start, 0x3000, 'memory zone starts at $3000')
         self.assertEqual(memzone_manager.zone('variables').end, 0x47FF, 'memory zone starts at $3000')

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -28,14 +28,23 @@ class TestPreprocessorSymbols(unittest.TestCase):
         preprocessor.create_symbol('s1', '57')
         preprocessor.create_symbol('s2', 's1*2')
 
-        t1 = preprocessor.resolve_symbols('s1')
+        line_id = LineIdentifier(1, 'test_preprocessor_resolve_symbols')
+
+        t1 = preprocessor.resolve_symbols(line_id, 's1')
         self.assertEqual(t1, '57', 's1 should resolve to 57')
 
-        t2 = preprocessor.resolve_symbols('s2')
+        t2 = preprocessor.resolve_symbols(line_id, 's2')
         self.assertEqual(t2, '57*2', 's2 should resolve to 57*2')
 
-        t3 = preprocessor.resolve_symbols('s1 + s2 + label1')
+        t3 = preprocessor.resolve_symbols(line_id, 's1 + s2 + label1')
         self.assertEqual(t3, '57 + 57*2 + label1', 's1 + s2 should resolve to 57 + 57*2')
+
+        # test infinite recursion detection
+        preprocessor.create_symbol('s3', 's4')
+        preprocessor.create_symbol('s4', '2*s5')
+        preprocessor.create_symbol('s5', 's3')
+        with self.assertRaises(SystemExit):
+            preprocessor.resolve_symbols(line_id, 's3')
 
     def test_preprocessor_comparisons(self):
         class MockPreprocessorCondition_True(IfPreprocessorCondition):

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -140,3 +140,26 @@ class TestPreprocessorSymbols(unittest.TestCase):
             '"George Washington!"',
             'symbol value should be "George Washington!"'
         )
+
+        l3: LineObject = LineOjectFactory.parse_line(
+            lineid,
+            '#define WITH_COMMENT (13 + 27) ; my comment',
+            isa_model,
+            global_scope,
+            memzone_mngr.global_zone,
+            memzone_mngr,
+            preprocessor,
+            0,
+        )[0]
+        self.assertTrue(isinstance(l3, DefineSymbolLine), 'l1 should be a DefineSymbolLine')
+        self.assertEqual(l3.comment, 'my comment', 'comment should be "my comment"')
+        dsl3: DefineSymbolLine = l3
+        self.assertEqual(dsl3.symbol.name, 'WITH_COMMENT', 'symbol name should be WITH_COMMENT')
+        self.assertEqual(dsl3.symbol.value, '(13 + 27)', 'symbol value should be (13 + 27)')
+        self.assertEqual(dsl3.symbol.created_line_id, lineid, 'symbol created line id should be lineid')
+        self.assertTrue(preprocessor.get_symbol('WITH_COMMENT') is not None, 'WITH_COMMENT should be defined')
+        self.assertEqual(
+            preprocessor.get_symbol('WITH_COMMENT').value,
+            '(13 + 27)',
+            'symbol value should be (13 + 27)'
+        )

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -223,7 +223,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
             'symbol value should be (13 + 27)'
         )
 
-    def test_compilation_control(self):
+    def test_compilation_contro_and_symbol_replacement(self):
         with pkg_resources.path(config_files, 'test_compilation_control.yaml') as fp:
             isa_model = AssemblerModel(str(fp), 0)
         label_scope = GlobalLabelScope(isa_model.registers)
@@ -266,6 +266,13 @@ class TestPreprocessorSymbols(unittest.TestCase):
             if not line_objs[i].compilable:
                 actual_no_compile_lines.append(i)
         self.assertEqual(actual_no_compile_lines, expected_no_compile_lines, 'no compile lines should be 9, 12, 18, 22, 26')
+
+        # symbol replacement
+        #   line 16 is "mov a, SYMBOL2", should become "mov a, 0"
+        #   line 18 is "mov a, SYMBOL1", should become "mov a, 1"
+
+        self.assertEqual(line_objs[16].instruction, 'mov a, 0', 'line 16 should be "mov a, 0"')
+        self.assertEqual(line_objs[18].instruction, 'mov a, 1', 'line 18 should be "mov a, 1"')
 
     def test_condition_stack(self):
         stack = ConsitionStack()

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -16,7 +16,7 @@ from bespokeasm.assembler.line_object.factory import LineOjectFactory
 from bespokeasm.assembler.label_scope import GlobalLabelScope
 from bespokeasm.assembler.line_object.preprocessor_line.define_symbol import DefineSymbolLine
 from bespokeasm.assembler.assembly_file import AssemblyFile
-from bespokeasm.assembler.preprocessor.condition_stack import ConsitionStack
+from bespokeasm.assembler.preprocessor.condition_stack import ConditionStack
 
 
 class TestPreprocessorSymbols(unittest.TestCase):
@@ -180,7 +180,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )[0]
         self.assertTrue(isinstance(l1, DefineSymbolLine), 'l1 should be a DefineSymbolLine')
@@ -200,7 +200,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )[0]
         self.assertTrue(isinstance(l2, DefineSymbolLine), 'l1 should be a DefineSymbolLine')
@@ -223,10 +223,10 @@ class TestPreprocessorSymbols(unittest.TestCase):
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
-            ConsitionStack(),
+            ConditionStack(),
             0,
         )[0]
-        self.assertTrue(isinstance(l3, DefineSymbolLine), 'l1 should be a DefineSymbolLine')
+        self.assertTrue(isinstance(l3, DefineSymbolLine), '3 should be a DefineSymbolLine')
         self.assertEqual(l3.comment, 'my comment', 'comment should be "my comment"')
         dsl3: DefineSymbolLine = l3
         self.assertEqual(dsl3.symbol.name, 'WITH_COMMENT', 'symbol name should be WITH_COMMENT')
@@ -238,6 +238,26 @@ class TestPreprocessorSymbols(unittest.TestCase):
             '(13 + 27)',
             'symbol value should be (13 + 27)'
         )
+
+        l4: LineObject = LineOjectFactory.parse_line(
+            lineid,
+            '#define CODE_SYMBOL push a  ; my comment',
+            isa_model,
+            global_scope,
+            memzone_mngr.global_zone,
+            memzone_mngr,
+            preprocessor,
+            ConditionStack(),
+            0,
+        )[0]
+        self.assertTrue(isinstance(l4, DefineSymbolLine), 'l4 should be a DefineSymbolLine')
+        self.assertEqual(l4.comment, 'my comment', 'comment should be "my comment"')
+        dsl4: DefineSymbolLine = l4
+        self.assertEqual(dsl4.symbol.name, 'CODE_SYMBOL', 'symbol name should be CODE_SYMBOL')
+        self.assertEqual(dsl4.symbol.value, 'push a', 'symbol value should be: push a')
+        self.assertEqual(dsl4.symbol.created_line_id, lineid, 'symbol created line id should be lineid')
+        self.assertTrue(preprocessor.get_symbol('CODE_SYMBOL') is not None, 'CODE_SYMBOL should be defined')
+        self.assertEqual(preprocessor.get_symbol('CODE_SYMBOL').value, 'push a', 'symbol value should be: push a')
 
     def test_compilation_contro_and_symbol_replacement(self):
         with pkg_resources.path(config_files, 'test_compilation_control.yaml') as fp:
@@ -291,7 +311,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
         self.assertEqual(line_objs[18].instruction, 'mov a, 1', 'line 18 should be "mov a, 1"')
 
     def test_condition_stack(self):
-        stack = ConsitionStack()
+        stack = ConditionStack()
         preprocessor = Preprocessor()
         preprocessor.create_symbol('s1', '57')
         preprocessor.create_symbol('s2', 's1*2')

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -56,3 +56,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
 
         c8 = PreprocessorCondition('#if s7 == 1<<4', LineIdentifier('test_preprocessor_comparisons', 8))
         self.assertTrue(c8.evaluate(preprocessor), 's7 == 1<<4 should be true')
+
+        # test implied != 0 comparison
+        c9 = PreprocessorCondition('#if s7', LineIdentifier('test_preprocessor_comparisons', 9))
+        self.assertTrue(c9.evaluate(preprocessor), 's7 should be true')

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -7,7 +7,7 @@ from test import test_code
 from bespokeasm.assembler.preprocessor import Preprocessor
 from bespokeasm.assembler.preprocessor.condition import \
     IfPreprocessorCondition, IfdefPreprocessorCondition, ElifPreprocessorCondition, \
-    ElsePreprocessorCondition, EndifPreprocessorCondition, PreprocessorCondition
+    ElsePreprocessorCondition, EndifPreprocessorCondition
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.model import AssemblerModel
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
@@ -38,9 +38,9 @@ class TestPreprocessorSymbols(unittest.TestCase):
         self.assertEqual(t3, '57 + 57*2 + label1', 's1 + s2 should resolve to 57 + 57*2')
 
     def test_preprocessor_comparisons(self):
-        class MockPreprocessorCondition_True(PreprocessorCondition):
+        class MockPreprocessorCondition_True(IfPreprocessorCondition):
             def __init__(self, line: LineIdentifier):
-                super().__init__('mock-true', line)
+                super().__init__('#if true', line)
 
             def __repr__(self) -> str:
                 return "MockPreprocessorCondition_True"
@@ -48,9 +48,9 @@ class TestPreprocessorSymbols(unittest.TestCase):
             def evaluate(self, preprocessor: Preprocessor) -> bool:
                 return True
 
-        class MockPreprocessorCondition_False(PreprocessorCondition):
+        class MockPreprocessorCondition_False(IfPreprocessorCondition):
             def __init__(self, line: LineIdentifier):
-                super().__init__('mock-false', line)
+                super().__init__('#if false', line)
 
             def __repr__(self) -> str:
                 return "MockPreprocessorCondition_False"

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -74,8 +74,15 @@ class TestPreprocessorSymbols(unittest.TestCase):
         c2 = IfPreprocessorCondition('#if s1 == s3', LineIdentifier('test_preprocessor_comparisons', 2))
         self.assertTrue(c2.evaluate(preprocessor), 's1 == s3 should be true')
 
+        # string comparisons
         c3 = IfPreprocessorCondition('#if s4 == s5', LineIdentifier('test_preprocessor_comparisons', 3))
         self.assertFalse(c3.evaluate(preprocessor), 's4 == s5 should be false')
+
+        c3b = IfPreprocessorCondition('#if s4 == "string_value1"', LineIdentifier('test_preprocessor_comparisons', 3))
+        self.assertTrue(c3b.evaluate(preprocessor), 's4 == "string_value1" should be true')
+
+        c3c = IfPreprocessorCondition('#if s4 == 42', LineIdentifier('test_preprocessor_comparisons', 3))
+        self.assertFalse(c3c.evaluate(preprocessor), 's4 == 42 should be false (string != number)')
 
         c4 = IfPreprocessorCondition('#if s4 == s6', LineIdentifier('test_preprocessor_comparisons', 4))
         self.assertTrue(c4.evaluate(preprocessor), 's4 == s6 should be true')

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -1,0 +1,58 @@
+import unittest
+
+from bespokeasm.assembler.preprocessor import Preprocessor
+from bespokeasm.assembler.preprocessor.condition import PreprocessorCondition
+from bespokeasm.assembler.line_identifier import LineIdentifier
+
+
+class TestPreprocessorSymbols(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_proprocessor_resolve_symbols(self):
+        preprocessor = Preprocessor()
+        preprocessor.create_symbol('s1', '57')
+        preprocessor.create_symbol('s2', 's1*2')
+
+        t1 = preprocessor.resolve_symbols('s1')
+        self.assertEqual(t1, '57', 's1 should resolve to 57')
+
+        t2 = preprocessor.resolve_symbols('s2')
+        self.assertEqual(t2, '57*2', 's2 should resolve to 57*2')
+
+        t3 = preprocessor.resolve_symbols('s1 + s2 + label1')
+        self.assertEqual(t3, '57 + 57*2 + label1', 's1 + s2 should resolve to 57 + 57*2')
+
+    def test_preprocessor_comparisons(self):
+        preprocessor = Preprocessor()
+        preprocessor.create_symbol('s1', '57')
+        preprocessor.create_symbol('s2', 's1*2')
+        preprocessor.create_symbol('s3', '57')
+        preprocessor.create_symbol('s4', 'string_value1')
+        preprocessor.create_symbol('s5', 'string_value2')
+        preprocessor.create_symbol('s6', 's4')
+        preprocessor.create_symbol('s7', '0x10')
+
+        c1 = PreprocessorCondition('#if s1 == s2', LineIdentifier('test_preprocessor_comparisons', 1))
+        self.assertFalse(c1.evaluate(preprocessor), 's1 == s2 should be false')
+
+        c2 = PreprocessorCondition('#if s1 == s3', LineIdentifier('test_preprocessor_comparisons', 2))
+        self.assertTrue(c2.evaluate(preprocessor), 's1 == s3 should be true')
+
+        c3 = PreprocessorCondition('#if s4 == s5', LineIdentifier('test_preprocessor_comparisons', 3))
+        self.assertFalse(c3.evaluate(preprocessor), 's4 == s5 should be false')
+
+        c4 = PreprocessorCondition('#if s4 == s6', LineIdentifier('test_preprocessor_comparisons', 4))
+        self.assertTrue(c4.evaluate(preprocessor), 's4 == s6 should be true')
+
+        c5 = PreprocessorCondition('#if s1 < s2', LineIdentifier('test_preprocessor_comparisons', 5))
+        self.assertTrue(c5.evaluate(preprocessor), 's1 < s2 should be true')
+
+        c6 = PreprocessorCondition('#if s4 < s5', LineIdentifier('test_preprocessor_comparisons', 6))
+        self.assertTrue(c6.evaluate(preprocessor), 's4 < s5 should be true')
+
+        c7 = PreprocessorCondition('#if s5 == "string_value2"', LineIdentifier('test_preprocessor_comparisons', 7))
+        self.assertTrue(c7.evaluate(preprocessor), 's5 == "string_value2" should be true')
+
+        c8 = PreprocessorCondition('#if s7 == 1<<4', LineIdentifier('test_preprocessor_comparisons', 8))
+        self.assertTrue(c8.evaluate(preprocessor), 's7 == 1<<4 should be true')

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -1,7 +1,7 @@
 import unittest
 
 from bespokeasm.assembler.preprocessor import Preprocessor
-from bespokeasm.assembler.preprocessor.condition import PreprocessorCondition
+from bespokeasm.assembler.preprocessor.condition import IfPreprocessorCondition, IfdefPreprocessorCondition
 from bespokeasm.assembler.line_identifier import LineIdentifier
 
 
@@ -33,30 +33,47 @@ class TestPreprocessorSymbols(unittest.TestCase):
         preprocessor.create_symbol('s6', 's4')
         preprocessor.create_symbol('s7', '0x10')
 
-        c1 = PreprocessorCondition('#if s1 == s2', LineIdentifier('test_preprocessor_comparisons', 1))
+        c1 = IfPreprocessorCondition('#if s1 == s2', LineIdentifier('test_preprocessor_comparisons', 1))
         self.assertFalse(c1.evaluate(preprocessor), 's1 == s2 should be false')
 
-        c2 = PreprocessorCondition('#if s1 == s3', LineIdentifier('test_preprocessor_comparisons', 2))
+        c2 = IfPreprocessorCondition('#if s1 == s3', LineIdentifier('test_preprocessor_comparisons', 2))
         self.assertTrue(c2.evaluate(preprocessor), 's1 == s3 should be true')
 
-        c3 = PreprocessorCondition('#if s4 == s5', LineIdentifier('test_preprocessor_comparisons', 3))
+        c3 = IfPreprocessorCondition('#if s4 == s5', LineIdentifier('test_preprocessor_comparisons', 3))
         self.assertFalse(c3.evaluate(preprocessor), 's4 == s5 should be false')
 
-        c4 = PreprocessorCondition('#if s4 == s6', LineIdentifier('test_preprocessor_comparisons', 4))
+        c4 = IfPreprocessorCondition('#if s4 == s6', LineIdentifier('test_preprocessor_comparisons', 4))
         self.assertTrue(c4.evaluate(preprocessor), 's4 == s6 should be true')
 
-        c5 = PreprocessorCondition('#if s1 < s2', LineIdentifier('test_preprocessor_comparisons', 5))
+        c5 = IfPreprocessorCondition('#if s1 < s2', LineIdentifier('test_preprocessor_comparisons', 5))
         self.assertTrue(c5.evaluate(preprocessor), 's1 < s2 should be true')
 
-        c6 = PreprocessorCondition('#if s4 < s5', LineIdentifier('test_preprocessor_comparisons', 6))
+        c6 = IfPreprocessorCondition('#if s4 < s5', LineIdentifier('test_preprocessor_comparisons', 6))
         self.assertTrue(c6.evaluate(preprocessor), 's4 < s5 should be true')
 
-        c7 = PreprocessorCondition('#if s5 == "string_value2"', LineIdentifier('test_preprocessor_comparisons', 7))
+        c7 = IfPreprocessorCondition('#if s5 == "string_value2"', LineIdentifier('test_preprocessor_comparisons', 7))
         self.assertTrue(c7.evaluate(preprocessor), 's5 == "string_value2" should be true')
 
-        c8 = PreprocessorCondition('#if s7 == 1<<4', LineIdentifier('test_preprocessor_comparisons', 8))
+        c8 = IfPreprocessorCondition('#if s7 == 1<<4', LineIdentifier('test_preprocessor_comparisons', 8))
         self.assertTrue(c8.evaluate(preprocessor), 's7 == 1<<4 should be true')
 
         # test implied != 0 comparison
-        c9 = PreprocessorCondition('#if s7', LineIdentifier('test_preprocessor_comparisons', 9))
+        c9 = IfPreprocessorCondition('#if s7', LineIdentifier('test_preprocessor_comparisons', 9))
         self.assertTrue(c9.evaluate(preprocessor), 's7 should be true')
+
+        # test expression on LHS
+        c10 = IfPreprocessorCondition('#if 1<<4 == s7', LineIdentifier('test_preprocessor_comparisons', 10))
+        self.assertTrue(c10.evaluate(preprocessor), '1<<4 == s7 should be true')
+
+        # test #ifdef
+        c11 = IfdefPreprocessorCondition('#ifdef s7', LineIdentifier('test_preprocessor_comparisons', 11))
+        self.assertTrue(c11.evaluate(preprocessor), 's7 should be defined')
+
+        c12 = IfdefPreprocessorCondition('#ifdef s8', LineIdentifier('test_preprocessor_comparisons', 12))
+        self.assertFalse(c12.evaluate(preprocessor), 's8 should not be defined')
+
+        c13 = IfdefPreprocessorCondition('#ifndef s7', LineIdentifier('test_preprocessor_comparisons', 11))
+        self.assertFalse(c13.evaluate(preprocessor), 's7 should be defined')
+
+        c14 = IfdefPreprocessorCondition('#ifndef s8', LineIdentifier('test_preprocessor_comparisons', 12))
+        self.assertTrue(c14.evaluate(preprocessor), 's8 should not be defined')


### PR DESCRIPTION
Generally added support for preprocessor symbols created with the C-like `#define` syntax, and compilation control with the `#if`/`#elif`/`#else`/`#endif` syntax. Details of how this implemented in in the [compilation control requirements document](docs/compilation-control-requirements.md)