### PR TITLE
Fixed bug with indirect indexed register operand parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Changes that are planned but not implemented yet:
   * unknown labels
 
 ## [Unreleased]
+* Fixed [reported bug](https://github.com/michaelkamprath/bespokeasm/issues/25) where indirect indexed register operands were not parsed properly.
 
 ## [0.4.0]
 * Added ability to create preprocessor macros/symbols with `#define` directive. Thes macros can then be used in code. Also added the ability to define preprocessor symbols on the command line and in the instruction set configuration file.

--- a/src/bespokeasm/assembler/model/operand/types/indirect_numeric.py
+++ b/src/bespokeasm/assembler/model/operand/types/indirect_numeric.py
@@ -21,7 +21,7 @@ class IndirectNumericOperand(NumericExpressionOperand):
 
     @cached_property
     def match_pattern(self) -> str:
-        return r'^\[\s*({0})\s*\]$'.format(super().match_pattern)
+        return r'\[\s*({0})\s*\]'.format(super().match_pattern)
 
     def parse_operand(
         self,
@@ -31,7 +31,7 @@ class IndirectNumericOperand(NumericExpressionOperand):
         memzone_manager: MemoryZoneManager,
     ) -> ParsedOperand:
         # first check that operand is what we expect
-        match = re.match(self.match_pattern, operand.strip())
+        match = re.match(f'^{self.match_pattern}$', operand.strip())
         if match is not None and len(match.groups()) > 0:
             return self._parse_bytecode_parts(
                 line_id,

--- a/test/config_files/test_indirect_indexed_register_operands.yaml
+++ b/test/config_files/test_indirect_indexed_register_operands.yaml
@@ -41,6 +41,18 @@ operand_sets:
           min: -128
           size: 8
           byte_align: true
+      defered_indexed_hl:
+        type: indirect_indexed_register
+        register: hl
+        bytecode:
+          value: 5
+          size: 3
+        index_operands:
+          indirect_addr:
+            type: indirect_numeric
+            argument:
+              size: 8
+              byte_align: true
       indirect_addr:
         type: indirect_numeric
         bytecode:

--- a/test/test_instruction_parsing.py
+++ b/test/test_instruction_parsing.py
@@ -287,7 +287,7 @@ class TestInstructionParsing(unittest.TestCase):
         self.assertIsInstance(ins5, InstructionLine)
         ins5.label_scope = TestInstructionParsing.label_values
         ins5.generate_bytes()
-        ins5.assertEqual(list(ins4.get_bytes()), [0xFF, 0xEF, 4, 0], 'instruction byte should match')
+        self.assertEqual(list(ins5.get_bytes()), [0xFF, 0xEF, 4, 0], 'instruction byte should match')
 
         with self.assertRaises(SystemExit, msg='no instruction  should match here'):
             bad1 = InstructionLine.factory(

--- a/test/test_instruction_parsing.py
+++ b/test/test_instruction_parsing.py
@@ -279,6 +279,16 @@ class TestInstructionParsing(unittest.TestCase):
         ins4.generate_bytes()
         self.assertEqual(list(ins4.get_bytes()), [0xFF, 0x8F, 0], 'instruction byte should match')
 
+        ins5 = InstructionLine.factory(
+            22, 'cmp [hl+[4]],0', 'some comment!',
+            isa_model, memzone_mngr.global_zone, memzone_mngr,
+        )
+        ins5.set_start_address(1212)
+        self.assertIsInstance(ins5, InstructionLine)
+        ins5.label_scope = TestInstructionParsing.label_values
+        ins5.generate_bytes()
+        ins5.assertEqual(list(ins4.get_bytes()), [0xFF, 0xEF, 4, 0], 'instruction byte should match')
+
         with self.assertRaises(SystemExit, msg='no instruction  should match here'):
             bad1 = InstructionLine.factory(
                 22, '  mov a, [sp+i]', 'some comment!',


### PR DESCRIPTION
Addresses a bug with parsing an indirect indexed register operands, notably when the index is a indirect value itself, such as `[x+[4]]`.

closes #25 