### PR TITLE
Fixed embedded strings bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Changes that are planned but not implemented yet:
 * Create a "align if needed" preprocessor directive paid that generates an `.align` directive if the bytecode in between the pair isn't naturally on the same page and can fit on the same page if aligned. An error would be benerated if the block of code can't fit on the same page regardless of alignment.
 
 ## [Unreleased]
+* Upgrade python version requirements to 3.11
+* Fixed a bug where embedded stringsd weren't properly parsed if they contained a newline character or there were multiple embedded strings per line
 
 ## [0.4.2]
 *  Added support for The Minimal 64x4 Home Computer with an example and updated assembler functionality to support it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,18 +4,18 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bespokeasm"
-version = "0.4.2"
+version = "0.4.3"
 authors = [
   { name="Michael Kamprath", email="michael@kamprath.net" },
 ]
 description = "A customizable byte code assembler that allows for the definition of custom instruction set architecture"
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
-    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.11",
     "Topic :: Software Development :: Assemblers",
 ]
 dependencies = [

--- a/src/bespokeasm/__init__.py
+++ b/src/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = '0.4.2'
+BESPOKEASM_VERSION_STR = '0.4.3b1'
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = '0.3.0'

--- a/src/bespokeasm/assembler/line_object/emdedded_string.py
+++ b/src/bespokeasm/assembler/line_object/emdedded_string.py
@@ -10,7 +10,7 @@ from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.line_identifier import LineIdentifier
 
 
-EMBEDDED_STRING_PATTERN = r'(?P<quote>[\"])((?:\\(?P=quote)|.)*)(?P=quote)'
+EMBEDDED_STRING_PATTERN = r'(?P<quote>[\"])((?:\\(?P=quote)|.|\n)*?)(?P=quote)'
 
 
 class EmbeddedString(LineWithBytes):

--- a/src/bespokeasm/assembler/line_object/factory.py
+++ b/src/bespokeasm/assembler/line_object/factory.py
@@ -22,7 +22,7 @@ class LineOjectFactory:
         flags=re.IGNORECASE | re.MULTILINE
     )
     PATTERN_INSTRUCTION_CONTENT = re.compile(
-        r'^([^\;\n]*)',
+        r'^([^;\v]*)(?:;.*)?$',
         flags=re.IGNORECASE | re.MULTILINE
     )
 
@@ -68,7 +68,7 @@ class LineOjectFactory:
                     log_verbosity,
                 ))
         else:
-            # resolve proprocessor symbols
+            # resolve preprocessor symbols
             instruction_str = preprocessor.resolve_symbols(line_id, instruction_str)
             # parse instruction
             while len(instruction_str) > 0:

--- a/src/bespokeasm/assembler/preprocessor/__init__.py
+++ b/src/bespokeasm/assembler/preprocessor/__init__.py
@@ -52,6 +52,7 @@ class Preprocessor:
         # Errors if there are recursion loops caused byt symbols that indirectly refer to themselves.
 
         # to make this fast, all symbol candidates should be identified first, then the symbols should be resolved
+        # TODO: ignore tokens that are in quoted strings
         found_symbols: list[str] = re.findall(f'\\b({SYMBOL_PATTERN})\\b', line_str)
         symbols_replaced: set[str] = set()
 

--- a/test/config_files/test_operand_features.yaml
+++ b/test/config_files/test_operand_features.yaml
@@ -240,3 +240,18 @@ instructions:
               argument:
                 size: 8
                 byte_align: true
+macros:
+  add_twice:
+    - operands:
+        count: 1
+        specific_operands:
+          numeric_expression:
+            list:
+              numeric_expression:
+                type: numeric
+                argument:
+                  size: 8
+                  byte_align: true
+      instructions:
+        - "add @ARG(0)"
+        - "add @ARG(0)"


### PR DESCRIPTION
This dress two parsing bugs with embedded strings:

1. When the embedded string contains a newline character `\n`
2. When a single line of code has multiple embedded strings separated by other instructions.

