### PR TITLE
Support for symbols in Sublime Text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ Changes that are planned but not implemented yet:
 ## [Unreleased]
 * Upgrade python version requirements to 3.11
 * Improved several error messages
-* Fixed a bug where embedded stringsd weren't properly parsed if they contained a newline character or there were multiple embedded strings per line
+* Fixed a bug where embedded strings weren't properly parsed if they contained a newline character or there were multiple embedded strings per line
 * Fixed a bug where parsing properly discriminate between labels starting with `BYTE` string and the `BYTEx()` operator.
 * Fixed a bug in generating the syntax highlighting configuration that caused mnemonics with special characters to not be highlighted properly.
+* Added support for symbol definitions in Sublime Text. Symbols defined are labels and constants.
 
 ## [0.4.2]
 *  Added support for The Minimal 64x4 Home Computer with an example and updated assembler functionality to support it.

--- a/src/bespokeasm/__init__.py
+++ b/src/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = '0.4.3b2'
+BESPOKEASM_VERSION_STR = '0.4.3b3'
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = '0.3.0'

--- a/src/bespokeasm/configgen/sublime/resources/SymbolsGlobal.tmPreferences.xml
+++ b/src/bespokeasm/configgen/sublime/resources/SymbolsGlobal.tmPreferences.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Source Global Symbol List</string>
+    <key>scope</key>
+    <string>source.bespokeasm variable.other.label.global</string>
+    <key>settings</key>
+    <dict>
+        <key>showInIndexedSymbolList</key>
+        <integer>1</integer>
+    </dict>
+</dict>
+</plist>

--- a/src/bespokeasm/configgen/sublime/resources/SymbolsLocal.tmPreferences.xml
+++ b/src/bespokeasm/configgen/sublime/resources/SymbolsLocal.tmPreferences.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Source Local Symbol List</string>
+    <key>scope</key>
+    <string>source.bespokeasm variable.other.label.global, source.bespokeasm variable.other.label.file, source.bespokeasm variable.other.label.local, source.bespokeasm variable.other.constant</string>
+    <key>settings</key>
+    <dict>
+        <key>showInSymbolList</key>
+        <integer>1</integer>
+        <key>symbolTransformation</key>
+        <string>
+            s/^(\.[\w\d_]*)/    $1/g;
+        </string>
+    </dict>
+</dict>
+</plist>

--- a/src/bespokeasm/configgen/sublime/resources/sublime-syntax.yaml
+++ b/src/bespokeasm/configgen/sublime/resources/sublime-syntax.yaml
@@ -16,9 +16,17 @@ contexts:
       captures:
         1: variable.other.constant
         2: keyword.operator.assignment
-    - match: ((?:\.|_|\w){1}[\w\d_]*)(\:)
+    - match: (\w{1}[\w\d_]*)(\:)
       captures:
-        1: variable.other.label
+        1: variable.other.label.global
+        2: punctuation.definition.variable.colon.label
+    - match: (\.{1}[\w\d_]*)(\:)
+      captures:
+        1: variable.other.label.local
+        2: punctuation.definition.variable.colon.label
+    - match: (_{1}[\w\d_]*)(\:)
+      captures:
+        1: variable.other.label.file
         2: punctuation.definition.variable.colon.label
     - match: \;
       scope: punctuation.definition.comment


### PR DESCRIPTION
Added support for symbols in Sublime Text. The symbols defined are all labels and constants, though only global labels and constants are placed in Sublime's project-scoped symbols list.