### PR TITLE
Named Label Scope Feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ Changes that are planned but not implemented yet:
   * missing `:` after labels
   * unknown labels
   * Disallow instructions on the same line as an `.org` directive
-* Add named label scopes. This would allow a label to be defined in a specific scope that can be shared across files.
 * Create a "align if needed" preprocessor directive paid that generates an `.align` directive if the bytecode in between the pair isn't naturally on the same page and can fit on the same page if aligned. An error would be benerated if the block of code can't fit on the same page regardless of alignment.
 * Update the `#ifdef` and related preprocessor directives to include detection of labels and constants.
 * Allow multiple `cstr` defininitions on the same line
@@ -24,7 +23,9 @@ Changes that are planned but not implemented yet:
 - Added support for instruction aliases: you can now specify an `aliases` field (a list of alternative mnemonics) in an instruction's configuration. All aliases are globally unique, are accepted as valid mnemonics in assembly source, and generate the same code as the root mnemonic. This does not apply to macros.
 - Added `#print` preprocessor directive for compile-time messages with optional verbosity gating and honoring conditional/mute controls.
 - Added Vim syntax highlighting generator via `bespokeasm generate-extension vim`. This creates Vim `syntax/` and `ftdetect/` files for your ISA.
+- Added **named label scopes** feature: Create custom symbol namespaces with user-defined prefixes that can be shared across files. Use `#create-scope "name" prefix="prefix_"`, `#use-scope "name"`, and `#deactivate-scope "name"` directives. Supports library workflows where scopes can be used before being defined.
 - Fixed a bug where `#include` directives were not properly processed when they were inside a conditional block.
+- Fixed a test isolation issue where instruction pattern caching caused pytest failures when different ISA configurations were used across test files.
 
 ## [0.5.1]
 - Support for preserving comments, integer formats, list formats, and file type in configuration files during `update-config` command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bespokeasm"
-version = "0.5.2b3"
+version = "0.5.2b4"
 authors = [
   { name="Michael Kamprath", email="michael@kamprath.net" },
 ]

--- a/src/bespokeasm/__init__.py
+++ b/src/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = '0.5.2b3'
+BESPOKEASM_VERSION_STR = '0.5.2b4'
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = '0.5.0'

--- a/src/bespokeasm/assembler/bytecode/assembled.py
+++ b/src/bespokeasm/assembler/bytecode/assembled.py
@@ -4,6 +4,7 @@ from typing import Literal
 from bespokeasm.assembler.bytecode.parts import ByteCodePart
 from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
 from bespokeasm.assembler.line_identifier import LineIdentifier
 
 
@@ -51,7 +52,13 @@ class AssembledInstruction:
     def parts(self):
         return self._parts
 
-    def get_words(self, label_scope: LabelScope, instruction_address: int, instruction_size: int) -> list[Word]:
+    def get_words(
+            self,
+            label_scope: LabelScope,
+            active_named_scopes: ActiveNamedScopeList,
+            instruction_address: int,
+            instruction_size: int,
+    ) -> list[Word]:
         '''
         Returns a list of words that represent the assembled instruction.
 
@@ -66,6 +73,7 @@ class AssembledInstruction:
             self._segment_size,
             self._multi_word_endian,
             label_scope,
+            active_named_scopes,
             instruction_address,
             instruction_size,
         )

--- a/src/bespokeasm/assembler/keywords.py
+++ b/src/bespokeasm/assembler/keywords.py
@@ -11,6 +11,7 @@ PREPROCESSOR_DIRECTIVES_SET = {
     'include', 'require', 'create_memzone', 'print',
     'define', 'if', 'elif', 'else', 'endif', 'ifdef', 'ifndef',
     'mute', 'unmute', 'emit',
+    'create-scope', 'use-scope', 'deactivate-scope',
 }
 
 EXPRESSION_FUNCTIONS_SET = set([

--- a/src/bespokeasm/assembler/label_scope/__init__.py
+++ b/src/bespokeasm/assembler/label_scope/__init__.py
@@ -51,9 +51,11 @@ class LabelScopeType(enum.Enum):
     GLOBAL = 0
     FILE = 1
     LOCAL = 2
+    NAMED = 3
 
     @classmethod
     def get_label_scope(cls, label: str) -> LabelScopeType:
+        """Get the label scope type for a given label. Does not check for named scopes."""
         if label.startswith('.'):
             return LabelScopeType.LOCAL
         elif label.startswith('_'):

--- a/src/bespokeasm/assembler/label_scope/named_scope_manager.py
+++ b/src/bespokeasm/assembler/label_scope/named_scope_manager.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import os
+import sys
+
+from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope import LabelScopeType
+from bespokeasm.assembler.line_identifier import LineIdentifier
+
+
+class NamedLabelScope(LabelScope):
+    """Represents a named scope."""
+
+    def __init__(self, name: str, prefix: str, scope_reference: str, defined_at: LineIdentifier):
+        super().__init__(LabelScopeType.NAMED, None, scope_reference)
+        self._name = name
+        self._prefix = prefix
+        self._defined_at = defined_at
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def prefix(self) -> str:
+        return self._prefix
+
+    @property
+    def defined_at(self) -> LineIdentifier:
+        return self._defined_at
+
+    def __str__(self) -> str:
+        return f'NamedLabelScope<{self.name}, prefix="{self.prefix}">'
+
+
+class NamedScopeManager:
+    """Manages named label scopes throughout the assembly process."""
+
+    def __init__(self):
+        # Global scope definitions: {scope_name: NamedScopeDefinition}
+        self._scope_definitions: dict[str, NamedLabelScope] = {}
+        self._used_prefixes: set[str] = set()
+
+    def create_scope(self, name: str, prefix: str, defined_at: LineIdentifier) -> None:
+        """Create a new named scope definition."""
+        # Validate scope name
+        if not name or ' ' in name or '\t' in name:
+            sys.exit(f"ERROR: {defined_at} - Scope name '{name}' cannot contain whitespace")
+
+        # Validate prefix
+        if not prefix or ' ' in prefix or '\t' in prefix:
+            sys.exit(
+                f"ERROR: {defined_at} - Scope prefix '{prefix}' cannot contain whitespace"
+            )
+
+        # Validate prefix doesn't start with '.' to avoid confusion with local scope
+        if prefix.startswith('.'):
+            sys.exit(
+                f"ERROR: {defined_at} - Scope prefix '{prefix}' cannot start with '.'"
+                ' as this conflicts with local scope syntax'
+            )
+
+        # Check for duplicate scope name
+        if name in self._scope_definitions:
+            existing_def = self._scope_definitions[name]
+            sys.exit(f"ERROR: {defined_at} - Scope '{name}' already defined at {existing_def.defined_at}")
+
+        # Check for duplicate prefix (warn if same scope, error if different scope)
+        if prefix in self._used_prefixes:
+            existing_scope = next((scope for scope in self._scope_definitions.values() if scope.prefix == prefix), None)
+            if existing_scope is not None:
+                if existing_scope.name == name:
+                    # warn if same scope
+                    print(
+                        f"WARNING: {defined_at} - Scope '{name}' defined with prefix '{prefix}' "
+                        f'but is already defined at {existing_scope.defined_at}',
+                        file=sys.stderr,
+                    )
+                else:
+                    # error if different scope
+                    sys.exit(
+                        f"ERROR: {defined_at} - Scope '{name}' defined with prefix '{prefix}' that "
+                        f"is already used by scope '{existing_scope.name}' defined at {existing_scope.defined_at}"
+                    )
+
+        # Create the scope definition
+        definition = NamedLabelScope(name, prefix, name, defined_at)
+        self._scope_definitions[name] = definition
+        self._used_prefixes.add(prefix)
+
+    def get_label_value(
+        self,
+        label: str,
+        current_scope: LabelScope,
+        active_named_scopes: ActiveNamedScopeList,
+        line_id: LineIdentifier,
+    ) -> int:
+        """Get the value of a label found in the active named scopes.
+
+        If not found, return None.
+        """
+        for name in active_named_scopes:
+            if name in self._scope_definitions:
+                scope = self._scope_definitions[name]
+                if label.startswith(scope.prefix):
+                    return scope.get_label_value(label, line_id)
+        return current_scope.get_label_value(label, line_id)
+
+    def set_label_value(
+        self,
+        label: str,
+        value: int,
+        line_id: LineIdentifier,
+        active_named_scopes: ActiveNamedScopeList,
+        is_constant: bool = False,
+    ) -> bool:
+        """Set the value of a label found in the active named scopes.
+
+        If an appropriate named scope for label prefix is not found,
+        returns False.
+
+        Important: Labels and constants can only be created in a named scope
+        if they are defined in the same file where that named scope was created.
+        This restriction allows libraries to control which labels belong to
+        their namespace. If a label with a named scope's prefix is defined in
+        a different file, it will fall back to the normal scope hierarchy
+        (global/file/local) instead of being added to the named scope.
+        """
+        for name in active_named_scopes:
+            if name in self._scope_definitions:
+                scope = self._scope_definitions[name]
+                if label.startswith(scope.prefix):
+                    # Labels and constants can only be created in the same file
+                    # where the named scope was created. This prevents external
+                    # code from polluting a library's namespace.
+                    # Normalize paths for comparison (relative vs absolute)
+                    scope_file = (
+                        os.path.abspath(scope.defined_at.filename)
+                        if scope.defined_at.filename
+                        else None
+                    )
+                    label_file = (
+                        os.path.abspath(line_id.filename)
+                        if line_id.filename
+                        else None
+                    )
+                    if scope_file != label_file:
+                        # Label prefix matches but wrong file
+                        # Let it fall back to normal scope hierarchy
+                        return False
+                    scope.set_label_value(label, value, line_id, LabelScopeType.NAMED)
+                    return True
+        return False
+
+    def get_scope_definition(self, name: str) -> NamedLabelScope:
+        return self._scope_definitions[name]
+
+
+class ActiveNamedScopeList(list[str]):
+    """Convenience class to manage active named scopes when processing an assembly file."""
+
+    def __init__(self, named_scope_manager: NamedScopeManager):
+        super().__init__()
+        self._named_scope_manager = named_scope_manager
+
+    def copy(self) -> ActiveNamedScopeList:
+        """Copy the active named scopes list, keeping a reference to the same named scope manager."""
+        new_list = ActiveNamedScopeList(self._named_scope_manager)
+        new_list.extend(self)
+        return new_list
+
+    def activate_named_scope(self, name: str):
+        """Activates a named scope for this line object. If already active, move to top of precedence."""
+        if name in self:
+            self.remove(name)
+        self.insert(0, name)
+
+    def deactivate_named_scope(self, name: str):
+        """Deactivates a named scope for this line object. If not active, do nothing."""
+        if name in self:
+            self.remove(name)
+
+    def clear_active_named_scopes(self):
+        """Clears all active named scopes for this line object."""
+        self.clear()
+
+    @property
+    def named_scope_manager(self) -> NamedScopeManager:
+        return self._named_scope_manager

--- a/src/bespokeasm/assembler/line_object/__init__.py
+++ b/src/bespokeasm/assembler/line_object/__init__.py
@@ -2,6 +2,7 @@ from typing import Literal
 
 from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.expression import EXPRESSION_PARTS_PATTERN
@@ -23,6 +24,7 @@ class LineObject:
         self._memzone = memzone
         self._compilable = True
         self._is_muted = False
+        self._active_named_scopes = None
 
     def __repr__(self):
         return str(self)
@@ -74,6 +76,14 @@ class LineObject:
     @label_scope.setter
     def label_scope(self, value):
         self._label_scope = value
+
+    @property
+    def active_named_scopes(self) -> ActiveNamedScopeList:
+        return self._active_named_scopes
+
+    @active_named_scopes.setter
+    def active_named_scopes(self, value: ActiveNamedScopeList):
+        self._active_named_scopes = value.copy()
 
     @property
     def memory_zone(self) -> MemoryZone:

--- a/src/bespokeasm/assembler/line_object/data_line.py
+++ b/src/bespokeasm/assembler/line_object/data_line.py
@@ -179,7 +179,7 @@ class DataLine(LineWithWords):
                 arg_val = arg_item
             elif isinstance(arg_item, str):
                 e: ExpressionNode = parse_expression(self.line_id, arg_item)
-                arg_val = e.get_value(self.label_scope, self.line_id)
+                arg_val = e.get_value(self.label_scope, self.active_named_scopes, self.line_id)
             else:
                 sys.exit(f'ERROR: line {self.line_id} - unknown data item "{arg_item}"')
             value_size = DataLine.DIRECTIVE_VALUE_BYTE_SIZE[self._directive]

--- a/src/bespokeasm/assembler/line_object/directive_line/address.py
+++ b/src/bespokeasm/assembler/line_object/directive_line/address.py
@@ -27,7 +27,7 @@ class AddressOrgLine(SetMemoryZoneLine):
     def address(self) -> int:
         """Returns the adjusted address value set by the .org directive.
         """
-        offset_value = self._address_expr.get_value(self.label_scope, self.line_id)
+        offset_value = self._address_expr.get_value(self.label_scope, self.active_named_scopes, self.line_id)
         if self._parsed_memzone_name is None:
             value = offset_value
         else:

--- a/src/bespokeasm/assembler/line_object/directive_line/factory.py
+++ b/src/bespokeasm/assembler/line_object/directive_line/factory.py
@@ -67,7 +67,7 @@ class DirectiveLine:
         current_memzone: MemoryZone,
         memzone_manager: MemoryZoneManager,
         isa_model: AssemblerModel,
-    ) -> LineObject:
+    ) -> LineObject | None:
         # for efficiency, if it doesn't start with a period, it is not a directive
         cleaned_line_str = line_str.strip()
         if not cleaned_line_str.startswith('.'):

--- a/src/bespokeasm/assembler/line_object/directive_line/fill_data.py
+++ b/src/bespokeasm/assembler/line_object/directive_line/fill_data.py
@@ -43,14 +43,14 @@ class FillDataLine(LineWithWords):
     @property
     def word_count(self) -> int:
         if self._count is None:
-            self._count = self._count_expr.get_value(self.label_scope, self.line_id)
+            self._count = self._count_expr.get_value(self.label_scope, self.active_named_scopes, self.line_id)
         return self._count
 
     def generate_words(self):
         if self._count is None:
-            self._count = self._count_expr.get_value(self.label_scope, self.line_id)
+            self._count = self._count_expr.get_value(self.label_scope, self.active_named_scopes, self.line_id)
         if self._value is None:
-            self._value = self._value_expr.get_value(self.label_scope, self.line_id)
+            self._value = self._value_expr.get_value(self.label_scope, self.active_named_scopes, self.line_id)
         value_mask = (1 << self._word_size) - 1
         self._words.extend([
             Word(self._value & value_mask, self._word_size, self._word_segment_size, self._intra_word_endianness)
@@ -95,7 +95,9 @@ class FillUntilDataLine(LineWithWords):
     @property
     def word_count(self) -> int:
         if self._fill_until_addr is None:
-            self._fill_until_addr = self._fill_until_addr_expr.get_value(self.label_scope, self.line_id)
+            self._fill_until_addr = self._fill_until_addr_expr.get_value(
+                self.label_scope, self.active_named_scopes, self.line_id
+            )
         if self._fill_until_addr >= self.address:
             return self._fill_until_addr - self.address + 1
         else:
@@ -105,9 +107,11 @@ class FillUntilDataLine(LineWithWords):
         """Finalize the bytes for this fill until line.
         """
         if self._fill_until_addr is None:
-            self._fill_until_addr = self._fill_until_addr_expr.get_value(self.label_scope, self.line_id)
+            self._fill_until_addr = self._fill_until_addr_expr.get_value(
+                self.label_scope, self.active_named_scopes, self.line_id
+            )
         if self._fill_value is None:
-            self._fill_value = self._fill_value_expr.get_value(self.label_scope, self.line_id)
+            self._fill_value = self._fill_value_expr.get_value(self.label_scope, self.active_named_scopes, self.line_id)
         if self.word_count > 0 and len(self._words) == 0:
             value_mask = (1 << self._word_size) - 1
             self._words.extend([

--- a/src/bespokeasm/assembler/line_object/directive_line/page_align.py
+++ b/src/bespokeasm/assembler/line_object/directive_line/page_align.py
@@ -54,7 +54,7 @@ class PageAlignLine(LineObject):
         """Sets the finalized address to the next page boundary.
         """
         if isinstance(self._page_size, ExpressionNode):
-            self._page_size = self._page_size.get_value(self.label_scope, self.line_id)
+            self._page_size = self._page_size.get_value(self.label_scope, self.active_named_scopes, self.line_id)
 
         if self._page_size == 1:
             self._address = address

--- a/src/bespokeasm/assembler/line_object/emdedded_string.py
+++ b/src/bespokeasm/assembler/line_object/emdedded_string.py
@@ -35,7 +35,7 @@ class EmbeddedString(LineWithWords):
             intra_word_endianness: Literal['little', 'big'],
             multi_word_endianness: Literal['little', 'big'],
             cstr_terminator: int = 0,
-    ) -> EmbeddedString:
+    ) -> EmbeddedString | None:
         # detyermine if string starts with a quoted string
         match = re.search(EmbeddedString.QUOTED_STRING_PATTERN, instruction)
         if match is None or len(match.groups()) != 2:

--- a/src/bespokeasm/assembler/line_object/factory.py
+++ b/src/bespokeasm/assembler/line_object/factory.py
@@ -2,6 +2,7 @@ import re
 import sys
 
 from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object.directive_line.factory import DirectiveLine
@@ -33,11 +34,13 @@ class LineOjectFactory:
                 line_str: str,
                 model: AssemblerModel,
                 label_scope: LabelScope,
+                active_named_scopes: ActiveNamedScopeList,
                 current_memzone: MemoryZone,
                 memzone_manager: MemoryZoneManager,
                 preprocessor: Preprocessor,
                 condition_stack: ConditionStack,
                 log_verbosity: int,
+                filename: str = None,
             ) -> list[LineObject]:
         # find comments
         comment_str = ''
@@ -61,11 +64,13 @@ class LineOjectFactory:
                     comment_str,
                     model,
                     label_scope,
+                    active_named_scopes,
                     current_memzone,
                     memzone_manager,
                     preprocessor,
                     condition_stack,
                     log_verbosity,
+                    filename,
                 ))
         else:
             # resolve preprocessor symbols
@@ -79,6 +84,7 @@ class LineOjectFactory:
                     comment_str,
                     model.registers,
                     label_scope,
+                    active_named_scopes,
                     current_memzone,
                 )
                 if line_obj is not None:

--- a/src/bespokeasm/assembler/line_object/instruction_line.py
+++ b/src/bespokeasm/assembler/line_object/instruction_line.py
@@ -16,6 +16,11 @@ class InstructionLine(LineWithWords):
     _INSTRUCTUION_EXTRACTION_PATTERN = None
 
     @classmethod
+    def reset_instruction_pattern_cache(cls):
+        """Reset the instruction extraction pattern cache for test isolation."""
+        cls._INSTRUCTUION_EXTRACTION_PATTERN = None
+
+    @classmethod
     def factory(
             cls,
             line_id: LineIdentifier,
@@ -24,7 +29,7 @@ class InstructionLine(LineWithWords):
             isa_model: AssemblerModel,
             current_memzone: MemoryZone,
             memzone_manager: MemoryZoneManager,
-    ) -> LineWithWords:
+    ) -> LineWithWords | None:
         """Tries to contruct a instruction line object from the passed instruction line"""
         # first, extract evertything up to the next extruction
         if cls._INSTRUCTUION_EXTRACTION_PATTERN is None:
@@ -51,8 +56,14 @@ class InstructionLine(LineWithWords):
             argument_str = instruction_str.strip()[len(command_str):]
 
             return InstructionLine(
-                line_id, command_str, argument_str, isa_model,
-                memzone_manager, instruction_str, comment, current_memzone,
+                line_id,
+                command_str,
+                argument_str,
+                isa_model,
+                memzone_manager,
+                instruction_str,
+                comment,
+                current_memzone,
             )
         else:
             return None
@@ -92,4 +103,11 @@ class InstructionLine(LineWithWords):
 
     def generate_words(self) -> bytearray:
         """Finalize the bytes for this line with the label assignemnts"""
-        self._words.extend(self._assembled_instruction.get_words(self.label_scope, self.address, self.word_count))
+        self._words.extend(
+            self._assembled_instruction.get_words(
+                self.label_scope,
+                self.active_named_scopes,
+                self.address,
+                self.word_count,
+            )
+        )

--- a/src/bespokeasm/assembler/line_object/label_line.py
+++ b/src/bespokeasm/assembler/line_object/label_line.py
@@ -2,6 +2,7 @@ import re
 import sys
 
 from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import INSTRUCTION_EXPRESSION_PATTERN
 from bespokeasm.assembler.line_object import LineObject
@@ -28,8 +29,9 @@ class LabelLine(LineObject):
                 comment: str,
                 registers: set[str],
                 label_scope: LabelScope,
+                active_named_scopes: ActiveNamedScopeList,
                 current_memzone: MemoryZone,
-            ) -> LineObject:
+            ) -> LineObject | None:
         """Tries to match the passed line string to the Label or Constant directive patterns.
         If succcessful, returns a constructed LabelLine object. If not, None is
         returned.
@@ -59,7 +61,7 @@ class LabelLine(LineObject):
                 line_obj = LabelLine(
                     line_id,
                     constant_label,
-                    value_expr.get_value(label_scope, line_id),
+                    value_expr.get_value(label_scope, active_named_scopes, line_id),
                     line_str,
                     comment,
                     current_memzone,

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/create_scope.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/create_scope.py
@@ -42,17 +42,12 @@ class CreateScopeLine(PreprocessorLine):
                 sys.exit(f'ERROR: {line_id} - Scope prefix cannot be empty')
 
             # Create the scope
-            try:
-                named_scope_manager.create_scope(scope_name, prefix, line_id)
-                self._scope_name = scope_name
-                self._prefix = prefix
+            named_scope_manager.create_scope(scope_name, prefix, line_id)
+            self._scope_name = scope_name
+            self._prefix = prefix
 
-                if log_verbosity >= 2:
-                    print(f'INFO: {line_id} - Created named scope "{scope_name}" with prefix "{prefix}"')
-
-            except SystemExit:
-                # Re-raise system exits (these are expected error conditions)
-                raise
+            if log_verbosity >= 2:
+                print(f'INFO: {line_id} - Created named scope "{scope_name}" with prefix "{prefix}"')
 
         else:
             sys.exit(f'ERROR: {line_id} - Invalid #create-scope directive syntax: {instruction}')

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/create_scope.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/create_scope.py
@@ -1,0 +1,69 @@
+import re
+import sys
+
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.model import AssemblerModel
+
+
+class CreateScopeLine(PreprocessorLine):
+    """Preprocessor line for #create-scope directive."""
+
+    PATTERN_CREATE_SCOPE = re.compile(
+        r'^#create-scope\s+"([^"]+)"\s*(?:prefix\s*=\s*"([^"]*)")?\s*$',
+        re.IGNORECASE
+    )
+
+    def __init__(
+        self,
+        line_id: LineIdentifier,
+        instruction: str,
+        comment: str,
+        memzone: MemoryZone,
+        isa_model: AssemblerModel,
+        named_scope_manager: NamedScopeManager,
+        log_verbosity: int
+    ) -> None:
+        """Create a new named scope definition."""
+        super().__init__(line_id, instruction, comment, memzone)
+
+        create_match = re.search(CreateScopeLine.PATTERN_CREATE_SCOPE, instruction.strip())
+        if create_match is not None:
+            scope_name = create_match.group(1)
+            prefix = create_match.group(2) if create_match.group(2) is not None else '_'
+
+            # Validate inputs
+            if not scope_name:
+                sys.exit(f'ERROR: {line_id} - Scope name cannot be empty')
+
+            if not prefix or prefix == '':
+                sys.exit(f'ERROR: {line_id} - Scope prefix cannot be empty')
+
+            # Create the scope
+            try:
+                named_scope_manager.create_scope(scope_name, prefix, line_id)
+                self._scope_name = scope_name
+                self._prefix = prefix
+
+                if log_verbosity >= 2:
+                    print(f'INFO: {line_id} - Created named scope "{scope_name}" with prefix "{prefix}"')
+
+            except SystemExit:
+                # Re-raise system exits (these are expected error conditions)
+                raise
+
+        else:
+            sys.exit(f'ERROR: {line_id} - Invalid #create-scope directive syntax: {instruction}')
+
+    @property
+    def scope_name(self) -> str:
+        return self._scope_name
+
+    @property
+    def prefix(self) -> str:
+        return self._prefix
+
+    def __repr__(self) -> str:
+        return f'CreateScopeLine<{self._scope_name}, prefix="{self._prefix}">'

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/deactivate_scope.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/deactivate_scope.py
@@ -1,0 +1,58 @@
+import re
+import sys
+
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.model import AssemblerModel
+
+
+class DeactivateScopeLine(PreprocessorLine):
+    """Preprocessor line for #deactivate-scope directive."""
+
+    PATTERN_DEACTIVATE_SCOPE = re.compile(
+        r'^#deactivate-scope\s+"([^"]+)"\s*$',
+        re.IGNORECASE
+    )
+
+    def __init__(
+        self,
+        line_id: LineIdentifier,
+        instruction: str,
+        comment: str,
+        memzone: MemoryZone,
+        isa_model: AssemblerModel,
+        named_scope_manager: NamedScopeManager,
+        filename: str,
+        log_verbosity: int
+    ) -> None:
+        """Deactivate a named scope for the current file."""
+        super().__init__(line_id, instruction, comment, memzone)
+
+        deactivate_match = re.search(DeactivateScopeLine.PATTERN_DEACTIVATE_SCOPE, instruction.strip())
+        if deactivate_match is not None:
+            scope_name = deactivate_match.group(1)
+
+            # Validate input
+            if not scope_name:
+                sys.exit(f'ERROR: {line_id} - Scope name cannot be empty')
+
+            self._scope_name = scope_name
+            self._filename = filename
+
+            if log_verbosity >= 2:
+                print(f'INFO: {line_id} - Deactivated named scope "{scope_name}" for file "{filename}"')
+        else:
+            sys.exit(f'ERROR: {line_id} - Invalid #deactivate-scope directive syntax: {instruction}')
+
+    @property
+    def scope_name(self) -> str:
+        return self._scope_name
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+
+    def __repr__(self) -> str:
+        return f'DeactivateScopeLine<{self._scope_name}, file="{self._filename}">'

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/factory.py
@@ -1,12 +1,16 @@
 from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object.preprocessor_line.condition_line import CONDITIONAL_LINE_PREFIX_LIST
 from bespokeasm.assembler.line_object.preprocessor_line.condition_line import ConditionLine
 from bespokeasm.assembler.line_object.preprocessor_line.create_memzone import CreateMemzoneLine
+from bespokeasm.assembler.line_object.preprocessor_line.create_scope import CreateScopeLine
+from bespokeasm.assembler.line_object.preprocessor_line.deactivate_scope import DeactivateScopeLine
 from bespokeasm.assembler.line_object.preprocessor_line.define_symbol import DefineSymbolLine
 from bespokeasm.assembler.line_object.preprocessor_line.print_line import PrintLine
 from bespokeasm.assembler.line_object.preprocessor_line.required_language import RequiredLanguageLine
+from bespokeasm.assembler.line_object.preprocessor_line.use_scope import UseScopeLine
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.model import AssemblerModel
@@ -23,13 +27,50 @@ class PreprocessorLineFactory:
         comment: str,
         isa_model: AssemblerModel,
         label_scope: LabelScope,
+        active_named_scopes: ActiveNamedScopeList,
         current_memzone: MemoryZone,
         memzone_manager: MemoryZoneManager,
         preprocessor: Preprocessor,
         condition_stack: ConditionStack,
         log_verbosity: int,
+        filename: str,
     ) -> list[LineObject]:
         '''Parse a preprocessor line.'''
+        if instruction.startswith('#create-scope '):
+            return [CreateScopeLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        isa_model,
+                        active_named_scopes.named_scope_manager,
+                        log_verbosity
+                    )]
+
+        if instruction.startswith('#use-scope '):
+            return [UseScopeLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        isa_model,
+                        active_named_scopes.named_scope_manager,
+                        filename,
+                        log_verbosity
+                    )]
+
+        if instruction.startswith('#deactivate-scope '):
+            return [DeactivateScopeLine(
+                        line_id,
+                        instruction,
+                        comment,
+                        current_memzone,
+                        isa_model,
+                        active_named_scopes.named_scope_manager,
+                        filename,
+                        log_verbosity
+                    )]
+
         if instruction.startswith('#require '):
             return [RequiredLanguageLine(
                         line_id,

--- a/src/bespokeasm/assembler/line_object/preprocessor_line/use_scope.py
+++ b/src/bespokeasm/assembler/line_object/preprocessor_line/use_scope.py
@@ -1,0 +1,59 @@
+import re
+import sys
+
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.line_object.preprocessor_line import PreprocessorLine
+from bespokeasm.assembler.memory_zone import MemoryZone
+from bespokeasm.assembler.model import AssemblerModel
+
+
+class UseScopeLine(PreprocessorLine):
+    """Preprocessor line for #use-scope directive."""
+
+    PATTERN_USE_SCOPE = re.compile(
+        r'^#use-scope\s+"([^"]+)"\s*$',
+        re.IGNORECASE
+    )
+
+    def __init__(
+        self,
+        line_id: LineIdentifier,
+        instruction: str,
+        comment: str,
+        memzone: MemoryZone,
+        isa_model: AssemblerModel,
+        named_scope_manager: NamedScopeManager,
+        filename: str,
+        log_verbosity: int
+    ) -> None:
+        """Activate a named scope for the current file."""
+        super().__init__(line_id, instruction, comment, memzone)
+
+        use_match = re.search(UseScopeLine.PATTERN_USE_SCOPE, instruction.strip())
+        if use_match is not None:
+            scope_name = use_match.group(1)
+
+            # Validate input
+            if not scope_name:
+                sys.exit(f'ERROR: {line_id} - Scope name cannot be empty')
+
+            # Activate the scope
+            self._scope_name = scope_name
+            self._filename = filename
+
+            if log_verbosity >= 2:
+                print(f'INFO: {line_id} - Activated named scope "{scope_name}" for file "{filename}"')
+        else:
+            sys.exit(f'ERROR: {line_id} - Invalid #use-scope directive syntax: {instruction}')
+
+    @property
+    def scope_name(self) -> str:
+        return self._scope_name
+
+    @property
+    def filename(self) -> str:
+        return self._filename
+
+    def __repr__(self) -> str:
+        return f'UseScopeLine<{self._scope_name}, file="{self._filename}">'

--- a/src/bespokeasm/assembler/model/operand/types/address.py
+++ b/src/bespokeasm/assembler/model/operand/types/address.py
@@ -9,6 +9,7 @@
 from bespokeasm.assembler.bytecode.parts import ExpressionByteCodePartInMemoryZone
 from bespokeasm.assembler.bytecode.parts import NumericByteCodePart
 from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.memory_zone.manager import GLOBAL_ZONE_NAME
@@ -54,10 +55,21 @@ class AddressByteCodePart(ExpressionByteCodePartInMemoryZone):
         return f'AddressByteCodePart<expression="{self._expression}",zone={self._memzone},' \
                f'slice_lab={self._is_lsb_bytes},match_msb={self._match_address_msb}>'
 
-    def get_value(self, label_scope: LabelScope, instruction_address: int, instruction_size: int) -> int:
+    def get_value(
+        self,
+        label_scope: LabelScope,
+        active_named_scopes: ActiveNamedScopeList,
+        instruction_address: int,
+        instruction_size: int,
+    ) -> int:
         if instruction_address is None:
             raise ValueError('AddressByteCodePart.get_value had no instruction_address passed')
-        value = super().get_value(label_scope, instruction_address, instruction_size)
+        value = super().get_value(
+            label_scope,
+            active_named_scopes,
+            instruction_address,
+            instruction_size,
+        )
 
         if self._is_lsb_bytes and self._match_address_msb:
             # mask out the MSBs of the address value. The`value_size` is interpreted as the number of LSB bytes

--- a/src/bespokeasm/assembler/model/operand/types/relative_address.py
+++ b/src/bespokeasm/assembler/model/operand/types/relative_address.py
@@ -5,6 +5,7 @@ from functools import cached_property
 from bespokeasm.assembler.bytecode.parts import ExpressionByteCodePartInMemoryZone
 from bespokeasm.assembler.bytecode.parts import NumericByteCodePart
 from bespokeasm.assembler.label_scope import LabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
@@ -45,10 +46,16 @@ class RelativeAddressByteCodePart(ExpressionByteCodePartInMemoryZone):
         self._max_relative_value = max_relative_value
         self._offset_from_instruction_end = offset_from_instruction_end
 
-    def get_value(self, label_scope: LabelScope, instruction_address: int, instruction_size: int) -> int:
+    def get_value(
+        self,
+        label_scope: LabelScope,
+        active_named_scopes: ActiveNamedScopeList,
+        instruction_address: int,
+        instruction_size: int,
+    ) -> int:
         if instruction_address is None:
             raise ValueError('RelativeAddressByteCodePart.get_value had no instruction_address passed')
-        expression_value = super().get_value(label_scope, instruction_address, instruction_size)
+        expression_value = super().get_value(label_scope, active_named_scopes, instruction_address, instruction_size)
         relative_value = expression_value - instruction_address
         if self._offset_from_instruction_end:
             # minus one to account for the current address being 1 byte of instruction size

--- a/src/bespokeasm/assembler/model/operand_set.py
+++ b/src/bespokeasm/assembler/model/operand_set.py
@@ -63,7 +63,7 @@ class OperandSet:
         operand_str: str,
         register_labels: set[str],
         memzone_manager: MemoryZoneManager,
-    ) -> ParsedOperand:
+    ) -> ParsedOperand | None:
         for operand in self._ordered_operand_list:
             op: ParsedOperand = operand.parse_operand(line_id, operand_str, register_labels, memzone_manager)
             if op is not None:
@@ -77,7 +77,7 @@ class OperandSet:
         line_id: LineIdentifier,
         operand_str: str,
         register_labels: set[str]
-    ) -> Operand:
+    ) -> Operand | None:
         for operand in self._ordered_operand_list:
             if operand.match_operand(line_id, operand_str, register_labels):
                 return operand
@@ -93,7 +93,7 @@ class OperandSetCollection(dict):
         registers: set[str],
         word_size: int,
         word_segment_size: int,
-    ):
+    ) -> None:
         super().__init__(self)
         for set_name, set_config in config_dict.items():
             self[set_name] = OperandSet(
@@ -113,5 +113,5 @@ class OperandSetCollection(dict):
         set_names = ','.join([str(v) for v in self.values()])
         return f'OperandSetCollection[{set_names}]'
 
-    def get_operand_set(self, key) -> OperandSet:
+    def get_operand_set(self, key) -> OperandSet | None:
         return self.get(key, None)

--- a/src/bespokeasm/assembler/preprocessor/condition.py
+++ b/src/bespokeasm/assembler/preprocessor/condition.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 import sys
 
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import INSTRUCTION_EXPRESSION_PATTERN
 from bespokeasm.assembler.preprocessor import Preprocessor
@@ -119,9 +121,10 @@ class IfPreprocessorCondition(PreprocessorCondition):
             lhs_value = lhs_resolved
             rhs_value = rhs_resolved
         else:
-            # can do a numeric comparison
-            lhs_value = lhs_expression.get_value(None, self._line)
-            rhs_value = rhs_expression.get_value(None, self._line)
+            # can do a numeric comparison. Note that label scopes and active named scopes are not used here as
+            # preprocessor conditions are not evaluated in a specific context.
+            lhs_value = lhs_expression.get_value(None, ActiveNamedScopeList(NamedScopeManager()), self._line)
+            rhs_value = rhs_expression.get_value(None, ActiveNamedScopeList(NamedScopeManager()), self._line)
 
         if self._operator == '==':
             return lhs_value == rhs_value

--- a/src/bespokeasm/configgen/sublime/resources/create-scope.sublime-snippet.xml
+++ b/src/bespokeasm/configgen/sublime/resources/create-scope.sublime-snippet.xml
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[#create-scope "$1" prefix="$2"]]></content>
+    <tabTrigger>&#35;create-scope</tabTrigger>
+    <scope>source.bespokeasm.##FILEEXTENSION##</scope>
+    <description>Create a named label scope with custom prefix</description>
+</snippet>

--- a/src/bespokeasm/configgen/sublime/resources/deactivate-scope.sublime-snippet.xml
+++ b/src/bespokeasm/configgen/sublime/resources/deactivate-scope.sublime-snippet.xml
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[#deactivate-scope "$1"]]></content>
+    <tabTrigger>&#35;deactivate-scope</tabTrigger>
+    <scope>source.bespokeasm.##FILEEXTENSION##</scope>
+    <description>Deactivate a named label scope</description>
+</snippet>

--- a/src/bespokeasm/configgen/sublime/resources/use-scope.sublime-snippet.xml
+++ b/src/bespokeasm/configgen/sublime/resources/use-scope.sublime-snippet.xml
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[#use-scope "$1"]]></content>
+    <tabTrigger>&#35;use-scope</tabTrigger>
+    <scope>source.bespokeasm.##FILEEXTENSION##</scope>
+    <description>Activate a named label scope</description>
+</snippet>

--- a/test/test_assembler_model.py
+++ b/test/test_assembler_model.py
@@ -5,6 +5,8 @@ import bespokeasm.assembler.model.operand_set as AS
 from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.assembler.label_scope import LabelScopeType
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.model import AssemblerModel
@@ -52,6 +54,7 @@ class TestConfigObject(unittest.TestCase):
         fp = pkg_resources.files(config_files).joinpath('eater-sap1-isa.yaml')
         model1 = AssemblerModel(str(fp), 0)
         memzone_mngr = MemoryZoneManager(model1.address_size, model1.default_origin)
+        named_scope_manager = NamedScopeManager()
 
         test_line_id = LineIdentifier(1212, 'test_instruction_parsing')
 
@@ -60,7 +63,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(pi1.word_count, 1, 'assembled instruciton is 1 byte')
         self.assertEqual(
-            pi1.get_words(TestConfigObject.label_values, 0x8000, pi1.word_count),
+            pi1.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                pi1.word_count
+            ),
             [Word(0x1F, model1.word_size, model1.word_segment_size, model1.intra_word_endianness)],
             'assembled instruction',
         )
@@ -70,7 +78,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(pi2.word_count, 1, 'assembled instruciton is 1 byte')
         self.assertEqual(
-            pi2.get_words(TestConfigObject.label_values, 0x8000, pi2.word_count),
+            pi2.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                pi2.word_count,
+            ),
             [Word(0x27, model1.word_size, model1.word_segment_size, model1.intra_word_endianness)],
             'assembled instruction',
         )
@@ -80,7 +93,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(pi3.word_count, 1, 'assembled instruciton is 1 byte')
         self.assertEqual(
-            pi3.get_words(TestConfigObject.label_values, 0x8000, pi3.word_count),
+            pi3.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                pi3.word_count,
+            ),
             [Word(0xE0, model1.word_size, model1.word_segment_size, model1.intra_word_endianness)],
             'assembled instruction'
         )
@@ -94,7 +112,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piA.word_count, 1, 'assembled instruciton is 1 byte')
         self.assertEqual(
-            piA.get_words(TestConfigObject.label_values, 0x8000, 1),
+            piA.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                1,
+            ),
             [Word(0b01000010, model2.word_size, model2.word_segment_size, model2.intra_word_endianness)],
             'assembled instruction'
         )
@@ -104,7 +127,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piB.word_count, 3, 'assembled instruciton is 3 byte')
         self.assertEqual(
-            piB.get_words(TestConfigObject.label_values, 0x8000, 3),
+            piB.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                3,
+            ),
             [
                 Word(0b01000110, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x22, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -118,7 +146,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piC.word_count, 1, 'assembled instruciton is 1 byte')
         self.assertEqual(
-            piC.get_words(TestConfigObject.label_values, 0x8000, 1),
+            piC.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                1,
+            ),
             [Word(0b10111010, model2.word_size, model2.word_segment_size, model2.intra_word_endianness)],
             'assembled instruction'
         )
@@ -128,7 +161,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piD.word_count, 4, 'assembled instruciton is 4 byte')
         self.assertEqual(
-            piD.get_words(TestConfigObject.label_values, 0x8000, 4),
+            piD.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                4,
+            ),
             [
                 Word(0b01110111, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x88, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -143,7 +181,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piE.word_count, 3, 'assembled instruciton is 3 byte')
         self.assertEqual(
-            piE.get_words(TestConfigObject.label_values, 0x8000, 3),
+            piE.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                3,
+            ),
             [
                 Word(0b01101111, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x88, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -157,7 +200,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piF.word_count, 3, 'assembled instruciton is 3 byte')
         self.assertEqual(
-            piF.get_words(TestConfigObject.label_values, 0x8000, 3),
+            piF.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                3,
+            ),
             [
                 Word(0b01101111, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x88, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -171,7 +219,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piG.word_count, 3, 'assembled instruciton is 3 byte')
         self.assertEqual(
-            piG.get_words(TestConfigObject.label_values, 0x8000, 3),
+            piG.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                3,
+            ),
             [
                 Word(0b01101111, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x88, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -185,7 +238,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piH.word_count, 5, 'assembled instruciton is 5 byte')
         self.assertEqual(
-            piH.get_words(TestConfigObject.label_values, 0x8000, 5),
+            piH.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                5,
+            ),
             [
                 Word(0b01110110, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x02, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -201,7 +259,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piI.word_count, 3, 'assembled instruciton is 3 byte')
         self.assertEqual(
-            piI.get_words(TestConfigObject.label_values, 0x8000, 3),
+            piI.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                3,
+            ),
             [
                 Word(0b01100110, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x02, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -215,7 +278,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piJ.word_count, 5, 'assembled instruciton is 3 byte')
         self.assertEqual(
-            piJ.get_words(TestConfigObject.label_values, 0x8000, 5),
+            piJ.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                5,
+            ),
             [
                 Word(0b11110110, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x00, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -231,7 +299,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piK.word_count, 3, 'assembled instruciton is 3 byte')
         self.assertEqual(
-            piK.get_words(TestConfigObject.label_values, 0x8000, 3),
+            piK.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                3,
+            ),
             [
                 Word(0b01101101, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x04, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
@@ -245,7 +318,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piL.word_count, 1, 'assembled instruciton is 1 byte')
         self.assertEqual(
-            piL.get_words(TestConfigObject.label_values, 0x8000, 1),
+            piL.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                1,
+            ),
             [Word(0b00001010, model2.word_size, model2.word_segment_size, model2.intra_word_endianness)],
             'pop to i'
         )
@@ -255,7 +333,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piM.word_count, 1, 'assembled instruciton is 1 byte')
         self.assertEqual(
-            piM.get_words(TestConfigObject.label_values, 0x8000, 1),
+            piM.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                1,
+            ),
             [Word(0b00001111, model2.word_size, model2.word_segment_size, model2.intra_word_endianness)],
             'just pop'
         )
@@ -265,7 +348,12 @@ class TestConfigObject(unittest.TestCase):
         )
         self.assertEqual(piN.word_count, 2, 'assembled instruciton is 2 byte')
         self.assertEqual(
-            piN.get_words(TestConfigObject.label_values, 0x8000, 2),
+            piN.get_words(
+                TestConfigObject.label_values,
+                ActiveNamedScopeList(named_scope_manager),
+                0x8000,
+                2,
+            ),
             [
                 Word(0b01000101, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),
                 Word(0x02, model2.word_size, model2.word_segment_size, model2.intra_word_endianness),

--- a/test/test_bytecode.py
+++ b/test/test_bytecode.py
@@ -6,6 +6,8 @@ from bespokeasm.assembler.bytecode.parts import ExpressionByteCodePart
 from bespokeasm.assembler.bytecode.parts import NumericByteCodePart
 from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.label_scope import GlobalLabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 
 
@@ -27,7 +29,7 @@ class TestBytecodeObjects(unittest.TestCase):
 
         ai1 = AssembledInstruction(123, parts1, 8, 8, 'big', 'big')
         self.assertEqual(ai1.word_count, 1)
-        words1 = ai1.get_words(label_values, 0x8000, 1)
+        words1 = ai1.get_words(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 1)
         self.assertEqual(words1, [Word(0xff, 8, 8, 'big')], 'generated words should match')
 
         parts2 = [
@@ -39,7 +41,7 @@ class TestBytecodeObjects(unittest.TestCase):
 
         ai2 = AssembledInstruction(456, parts2, 8, 8, 'big', 'big')
         self.assertEqual(ai2.word_count, 8)
-        words2 = ai2.get_words(label_values, 0x8000, 8)
+        words2 = ai2.get_words(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 8)
         self.assertEqual(
             words2,
             [
@@ -68,19 +70,27 @@ class TestBytecodeObjects(unittest.TestCase):
 
         c1 = CompositeByteCodePart([p1, p2], False, 'big', 'big', test_line_id, 8, 8)
         self.assertEqual(5, c1.value_size, 'bit size should match')
-        self.assertEqual(7, c1.get_value(label_values, 0x8000, 5), 'value should match')
+        self.assertEqual(
+            7, c1.get_value(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 5), 'value should match'
+        )
 
         c2 = CompositeByteCodePart([p2, p1], False, 'big', 'big', test_line_id, 8, 8)
         self.assertEqual(5, c2.value_size, 'bit size should match')
-        self.assertEqual(25, c2.get_value(label_values, 0x8000, 5), 'value should match')
+        self.assertEqual(
+            25, c2.get_value(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 5), 'value should match'
+        )
 
         c3 = CompositeByteCodePart([p1, p2, p3], False, 'big', 'big', test_line_id, 8, 8)
         self.assertEqual(9, c3.value_size, 'bit size should match')
-        self.assertEqual(127, c3.get_value(label_values, 0x8000, 9), 'value should match')
+        self.assertEqual(
+            127, c3.get_value(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 9), 'value should match'
+        )
 
         c4 = CompositeByteCodePart([p1, p2, p1], False, 'big', 'big', test_line_id, 8, 8)
         self.assertEqual(8, c4.value_size, 'bit size should match')
-        self.assertEqual(57, c4.get_value(label_values, 0x8000, 8), 'value should match')
+        self.assertEqual(
+            57, c4.get_value(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 8), 'value should match'
+        )
 
     def test_compact_parts_to_words(self):
         test_line_id = LineIdentifier(1, 'test_compact_parts_to_words')
@@ -93,7 +103,9 @@ class TestBytecodeObjects(unittest.TestCase):
             NumericByteCodePart(3, 4, False, 'big', 'big', test_line_id, 8, 8),
         ]
 
-        words = CompositeByteCodePart.compact_parts_to_words(parts, 8, 8, 'big', label_values, 0x8000, 1)
+        words = CompositeByteCodePart.compact_parts_to_words(
+            parts, 8, 8, 'big', label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 1
+        )
         self.assertEqual(
             words,
             [Word(0x12, 8, 8, 'big'), Word(0x30, 8, 8, 'big')],
@@ -107,7 +119,9 @@ class TestBytecodeObjects(unittest.TestCase):
             NumericByteCodePart(2, 8, False, 'big', 'big', test_line_id, 16, 8),
             NumericByteCodePart(3, 4, False, 'big', 'big', test_line_id, 16, 8),
         ]
-        words = CompositeByteCodePart.compact_parts_to_words(parts, 16, 8, 'big', label_values, 0x8000, 1)
+        words = CompositeByteCodePart.compact_parts_to_words(
+            parts, 16, 8, 'big', label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 1
+        )
         self.assertEqual(
             words,
             [Word(0x1023, 16, 8, 'big')],
@@ -121,7 +135,9 @@ class TestBytecodeObjects(unittest.TestCase):
             NumericByteCodePart(2, 16, False, 'big', 'big', test_line_id, 32, 8),
             NumericByteCodePart(3, 8, False, 'big', 'big', test_line_id, 32, 8),
         ]
-        words = CompositeByteCodePart.compact_parts_to_words(parts, 32, 8, 'big', label_values, 0x8000, 1)
+        words = CompositeByteCodePart.compact_parts_to_words(
+            parts, 32, 8, 'big', label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 1
+        )
         self.assertEqual(
             words,
             [Word(0x10002030, 32, 8, 'big')],
@@ -150,7 +166,7 @@ class TestBytecodeObjects(unittest.TestCase):
             'big',
         )
         self.assertEqual(ai1.word_count, 1)
-        words1 = ai1.get_words(label_values, 0x8000, 1)
+        words1 = ai1.get_words(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 1)
         self.assertEqual(words1, [Word(0xff00, 16, 8, 'big')], 'generated words should match')
 
         test_line_id = LineIdentifier(2, 'test_bytecode_assembly_16bit_word')
@@ -170,7 +186,7 @@ class TestBytecodeObjects(unittest.TestCase):
             'big',
         )
         self.assertEqual(ai2.word_count, 5)
-        words2 = ai2.get_words(label_values, 0x8000, 8)
+        words2 = ai2.get_words(label_values, ActiveNamedScopeList(NamedScopeManager()), 0x8000, 8)
         self.assertEqual(
             words2,
             [

--- a/test/test_configgen.py
+++ b/test/test_configgen.py
@@ -251,8 +251,9 @@ class TestConfigurationGeneration(unittest.TestCase):
                 'include', 'require', 'create_memzone', 'print', 'define', 'if',
                 'elif', 'else', 'endif', 'ifdef', 'ifndef',
                 'mute', 'unmute', 'emit',
+                'create-scope', 'use-scope', 'deactivate-scope',
             ],
-            'data type directives'
+            'preprocessor directives'
         )
         self.assertIsFile(os.path.join(test_tmp_dir, 'bespokeasm-test.sublime-color-scheme'))
         self.assertIsFile(os.path.join(test_tmp_dir, 'bespokeasm-test__cstr.sublime-snippet'))
@@ -337,8 +338,9 @@ class TestConfigurationGeneration(unittest.TestCase):
                 'include', 'require', 'create_memzone', 'print', 'define',
                 'if', 'elif', 'else', 'endif', 'ifdef', 'ifndef',
                 'mute', 'unmute', 'emit',
+                'create-scope', 'use-scope', 'deactivate-scope',
             ],
-            'data type directives'
+            'preprocessor directives'
         )
         self.assertIsFile(os.path.join(test_tmp_dir, 'tester-assembly.sublime-color-scheme'))
         self.assertIsFile(os.path.join(test_tmp_dir, 'tester-assembly__cstr.sublime-snippet'))

--- a/test/test_directive_lines.py
+++ b/test/test_directive_lines.py
@@ -6,6 +6,8 @@ from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.label_scope import GlobalLabelScope
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.assembler.label_scope import LabelScopeType
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object import LineWithWords
@@ -41,7 +43,7 @@ class TestDirectiveLines(unittest.TestCase):
         label_values = GlobalLabelScope(['a', 'b', 'sp', 'mar'])
         label_values.set_label_value('a_const', 12, 1)
 
-        o1 = DirectiveLine.factory(
+        o1: LineObject = DirectiveLine.factory(
             1234,
             '.org $1',
             'set address to 0=x100',
@@ -97,6 +99,7 @@ class TestDirectiveLines(unittest.TestCase):
             TestDirectiveLines.isa_model,
         )
         o5.label_scope = label_values
+        o5.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertIsInstance(o5, AddressOrgLine)
         self.assertEqual(o5.address, 12)
 
@@ -110,6 +113,7 @@ class TestDirectiveLines(unittest.TestCase):
                 TestDirectiveLines.isa_model,
             )
             e1.label_scope = label_values
+            e1.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
             e1.address
 
         # test with memory zones
@@ -122,6 +126,7 @@ class TestDirectiveLines(unittest.TestCase):
             TestDirectiveLines.isa_model,
         )
         o6.label_scope = label_values
+        o6.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertIsInstance(o6, AddressOrgLine)
         self.assertEqual(o6.address, 14)
 
@@ -134,6 +139,7 @@ class TestDirectiveLines(unittest.TestCase):
             TestDirectiveLines.isa_model,
         )
         o7.label_scope = label_values
+        o7.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertIsInstance(o7, AddressOrgLine)
         self.assertEqual(o7.address, 15)
 
@@ -155,6 +161,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o1, FillDataLine)
         o1.label_scope = label_values
+        o1.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o1.word_count, 32, 'has 32 words')
         o1.generate_words()
         self.assertEqual(o1.get_words(), [
@@ -178,6 +185,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o2, FillDataLine)
         o2.label_scope = label_values
+        o2.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o2.word_count, 255, 'has 255 words')
         o2.generate_words()
         self.assertEqual(o2.get_words(), [
@@ -199,6 +207,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o2b, FillDataLine)
         o2b.label_scope = label_values
+        o2b.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o2b.word_count, 161, 'has 161 words')
         o2b.generate_words()
         self.assertEqual(o2b.get_words(), [
@@ -220,6 +229,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o3, FillDataLine)
         o3.label_scope = label_values
+        o3.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o3.word_count, 4, 'has 4 words')
         o3.generate_words()
         self.assertEqual(o3.get_words(), [
@@ -242,6 +252,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o4, FillDataLine)
         o4.label_scope = label_values
+        o4.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o4.word_count, 40, 'has 40 words')
         o4.generate_words()
         self.assertEqual(o4.get_words(), [
@@ -263,6 +274,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o5, FillDataLine)
         o5.label_scope = label_values
+        o5.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o5.word_count, 15, 'has 15 words')
         o5.generate_words()
         self.assertEqual(o5.get_words(), [
@@ -284,6 +296,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o6, FillDataLine)
         o6.label_scope = label_values
+        o6.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o6.word_count, 30, 'has 30 words')
         o6.generate_words()
         self.assertEqual(o6.get_words(), [
@@ -305,6 +318,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o6, FillDataLine)
         o6.label_scope = label_values
+        o6.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o6.word_count, 42, 'has 42 words')
         o6.generate_words()
         self.assertEqual(o6.get_words(), [
@@ -326,6 +340,7 @@ class TestDirectiveLines(unittest.TestCase):
         )
         self.assertIsInstance(o7, FillDataLine)
         o7.label_scope = label_values
+        o7.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o7.word_count, 168, 'has 168 words')
         o7.generate_words()
         self.assertEqual(o7.get_words(), [
@@ -352,6 +367,7 @@ class TestDirectiveLines(unittest.TestCase):
         self.assertIsInstance(o1, FillUntilDataLine)
         o1.set_start_address(0x42)
         o1.label_scope = label_values
+        o1.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o1.word_count, (0x100-0x42+1), 'must have the right number of words')
         o1.generate_words()
         self.assertEqual(o1.get_words(), [
@@ -375,6 +391,7 @@ class TestDirectiveLines(unittest.TestCase):
         self.assertIsInstance(o2, FillUntilDataLine)
         o2.set_start_address(0xF)
         o2.label_scope = label_values
+        o2.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o2.word_count, 1, 'must have the right number of words')
         o2.generate_words()
         self.assertEqual(o2.get_words(), [
@@ -397,6 +414,7 @@ class TestDirectiveLines(unittest.TestCase):
         self.assertIsInstance(o3, FillUntilDataLine)
         o3.set_start_address(0xF)
         o3.label_scope = label_values
+        o3.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(o3.word_count, 0x81, 'must have the right number of words')
         o3.generate_words()
         self.assertEqual(o3.get_words(), [
@@ -425,6 +443,7 @@ class TestDirectiveLines(unittest.TestCase):
         self.assertIsInstance(t1, LineWithWords)
         t1.set_start_address(0xF)
         t1.label_scope = label_values
+        t1.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(t1.byte_size, 15, 'must have the right number of bytes')
         self.assertEqual(t1.word_count, 15, 'must have the right number of words for 8-bit words')
         t1.generate_words()
@@ -442,6 +461,7 @@ class TestDirectiveLines(unittest.TestCase):
         self.assertIsInstance(t1, LineWithWords)
         t2.set_start_address(0xF)
         t2.label_scope = label_values
+        t2.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(t2.byte_size, 15, 'must have the right number of bytes')
         self.assertEqual(t2.word_count, 15, 'must have the right number of words for 8-bit words')
         t2.generate_words()
@@ -498,6 +518,7 @@ class TestDirectiveLines(unittest.TestCase):
             local_isa_model
         )
         t4.label_scope = label_values
+        t4.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertIsInstance(t4, PageAlignLine)
         t4.set_start_address(3)
         self.assertEqual(t4.address, 4)

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -4,6 +4,8 @@ import unittest
 from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.engine import Assembler
 from bespokeasm.assembler.label_scope import GlobalLabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object import LineWithWords
@@ -44,6 +46,7 @@ class TestAssemblerEngine(unittest.TestCase):
                 'nop ; do nothing',
                 isa_model,
                 label_values,
+                ActiveNamedScopeList(NamedScopeManager()),
                 memzone_mngr.global_zone,
                 memzone_mngr,
                 preprocessor,
@@ -59,6 +62,7 @@ class TestAssemblerEngine(unittest.TestCase):
                 'the_byte: .byte 0x88 ; label and instruction',
                 isa_model,
                 label_values,
+                ActiveNamedScopeList(NamedScopeManager()),
                 memzone_mngr.global_zone,
                 memzone_mngr,
                 preprocessor,
@@ -75,6 +79,7 @@ class TestAssemblerEngine(unittest.TestCase):
                 'the_instr: mov a, [the_byte] ; label and instruction',
                 isa_model,
                 label_values,
+                ActiveNamedScopeList(NamedScopeManager()),
                 memzone_mngr.global_zone,
                 memzone_mngr,
                 preprocessor,
@@ -85,10 +90,12 @@ class TestAssemblerEngine(unittest.TestCase):
 
         # "assemble" the line objects to a dictionary
         line_dict: dict[int, LineObject] = {}
+        active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         for lobj in line_objects:
             lobj.set_start_address(lobj.memory_zone.current_address)
             lobj.memory_zone.current_address = lobj.address + lobj.word_count
             lobj.label_scope = label_values
+            lobj.active_named_scopes = active_named_scopes
             if isinstance(lobj, LabelLine) and not lobj.is_constant:
                 lobj.label_scope.set_label_value(lobj.get_label(), lobj.get_value(), lobj.line_id)
             line_dict[lobj.address] = lobj
@@ -137,6 +144,7 @@ class TestAssemblerEngine(unittest.TestCase):
                 'nop ; do nothing',
                 isa_model,
                 label_values,
+                ActiveNamedScopeList(NamedScopeManager()),
                 memzone_mngr.global_zone,
                 memzone_mngr,
                 preprocessor,
@@ -151,6 +159,7 @@ class TestAssemblerEngine(unittest.TestCase):
                 'mov [$1234], [$8899] ; move it',
                 isa_model,
                 label_values,
+                ActiveNamedScopeList(NamedScopeManager()),
                 memzone_mngr.global_zone,
                 memzone_mngr,
                 preprocessor,
@@ -165,6 +174,7 @@ class TestAssemblerEngine(unittest.TestCase):
                 'my_label: push [$1234] ; push it real good',
                 isa_model,
                 label_values,
+                ActiveNamedScopeList(NamedScopeManager()),
                 memzone_mngr.global_zone,
                 memzone_mngr,
                 preprocessor,
@@ -179,6 +189,7 @@ class TestAssemblerEngine(unittest.TestCase):
                 'jmp my_label ; get out of here',
                 isa_model,
                 label_values,
+                ActiveNamedScopeList(NamedScopeManager()),
                 memzone_mngr.global_zone,
                 memzone_mngr,
                 preprocessor,
@@ -189,10 +200,12 @@ class TestAssemblerEngine(unittest.TestCase):
 
         # "assemble" the line objects to a dictionary
         line_dict: dict[int, LineObject] = {}
+        active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         for lobj in line_objects:
             lobj.set_start_address(lobj.memory_zone.current_address)
             lobj.memory_zone.current_address = lobj.address + lobj.word_count
             lobj.label_scope = label_values
+            lobj.active_named_scopes = active_named_scopes
             if isinstance(lobj, LabelLine) and not lobj.is_constant:
                 lobj.label_scope.set_label_value(lobj.get_label(), lobj.get_value(), lobj.line_id)
             line_dict[lobj.address] = lobj

--- a/test/test_expression.py
+++ b/test/test_expression.py
@@ -1,6 +1,8 @@
 import unittest
 
 from bespokeasm.assembler.label_scope import GlobalLabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.expression import parse_expression
 
@@ -20,97 +22,105 @@ class TestExpression(unittest.TestCase):
 
     def test_expression_parsing(self):
         line_id = LineIdentifier(1212, 'test_expression_parsing')
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
 
         self.assertEqual(
-            parse_expression(line_id, '1 + 2').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, '1 + 2').get_value(labels, scopes, 1),
             3, 'simple expression: 1+2'
         )
         self.assertEqual(
-            parse_expression(line_id, '(value_1 - MixedCase)/5').get_value(TestExpression.label_values, 2),
+            parse_expression(line_id, '(value_1 - MixedCase)/5').get_value(labels, scopes, 2),
             2, 'label expression: (value_1 - two)/5'
         )
         self.assertEqual(
-            parse_expression(line_id, 'the_8_ball').get_value(TestExpression.label_values, 3),
+            parse_expression(line_id, 'the_8_ball').get_value(labels, scopes, 3),
             8, 'label expression: 8_ball'
         )
         self.assertEqual(
-            parse_expression(line_id, '8675309').get_value(TestExpression.label_values, 4),
+            parse_expression(line_id, '8675309').get_value(labels, scopes, 4),
             8675309, 'numeric expression: 8675309'
         )
         self.assertEqual(
-            parse_expression(line_id, 'value_1-2').get_value(TestExpression.label_values, 5),
+            parse_expression(line_id, 'value_1-2').get_value(labels, scopes, 5),
             10, 'numeric expression: value_1-2'
         )
         self.assertEqual(
-            parse_expression(line_id, '3+12/3').get_value(TestExpression.label_values, 6),
+            parse_expression(line_id, '3+12/3').get_value(labels, scopes, 6),
             7, 'test precedence order: 3+12/3 = 7'
         )
         self.assertEqual(
-            parse_expression(line_id, '0-(3+7)').get_value(TestExpression.label_values, 7),
+            parse_expression(line_id, '0-(3+7)').get_value(labels, scopes, 7),
             -10, 'test handling of leading sign: -(3+7) = -10'
         )
         self.assertEqual(
-            parse_expression(line_id, '8*( MAX_N + 1 )  ').get_value(TestExpression.label_values, 8),
+            parse_expression(line_id, '8*( MAX_N + 1 )  ').get_value(labels, scopes, 8),
             168, 'test handling of leading sign: 8*(MAX_N+1) = 168'
         )
         self.assertEqual(
-            parse_expression(line_id, '(MAX_N + 3)%5').get_value(TestExpression.label_values, line_id),
+            parse_expression(line_id, '(MAX_N + 3)%5').get_value(labels, scopes, line_id),
             3, 'test handling of modulo: (MAX_N + 3)%5 = 3'
         )
         self.assertEqual(
-            parse_expression(line_id, '(MAX_N + 3) % %101').get_value(TestExpression.label_values, line_id),
+            parse_expression(line_id, '(MAX_N + 3) % %101').get_value(labels, scopes, line_id),
             3, 'test handling of modulo: (MAX_N + 3) % %101 = 3'
         )
         self.assertEqual(
-            parse_expression(line_id, 'BYTECODE_LL0').get_value(TestExpression.label_values, line_id),
+            parse_expression(line_id, 'BYTECODE_LL0').get_value(labels, scopes, line_id),
             0x07, 'test handling of label with prefix: BYTECODE_LL0'
         )
 
         with self.assertRaises(SyntaxError, msg='only integer numeric values are supported'):
-            parse_expression(1212, '(value_1/5)/2.4').get_value(TestExpression.label_values, 100)
+            parse_expression(1212, '(value_1/5)/2.4').get_value(labels, scopes, 100)
 
     def test_expression_numeric_types(self):
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(
-            parse_expression(1212, '$100/0x80').get_value(TestExpression.label_values, 1),
+            parse_expression(1212, '$100/0x80').get_value(labels, scopes, 1),
             2, 'test hexadecimal math: $100/0x80'
         )
         self.assertEqual(
-            parse_expression(1212, '%10000000/$2').get_value(TestExpression.label_values, 2),
+            parse_expression(1212, '%10000000/$2').get_value(labels, scopes, 2),
             64, 'test binary math: %1000000/$2'
         )
         self.assertEqual(
-            parse_expression(1212, '32/b10').get_value(TestExpression.label_values, 3),
+            parse_expression(1212, '32/b10').get_value(labels, scopes, 3),
             16, 'test binary math: 32/b10'
         )
 
     def test_expression_result_integer_casting(self):
         # resolved values are cast to an integer, truncating the fractional part
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(
-            parse_expression(1212, 'value_1/5').get_value(TestExpression.label_values, 1),
+            parse_expression(1212, 'value_1/5').get_value(labels, scopes, 1),
             2, 'test rounding: 12/5 = 2'
         )
         self.assertEqual(
-            parse_expression(1212, '10/3/2').get_value(TestExpression.label_values, 2),
+            parse_expression(1212, '10/3/2').get_value(labels, scopes, 2),
             1, 'test rounding: 10/3/2 = 1'
         )
 
     def test_bitwise_operators(self):
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(
-            parse_expression(111, 'b11110000&b10101010').get_value(TestExpression.label_values, 1),
+            parse_expression(111, 'b11110000&b10101010').get_value(labels, scopes, 1),
             int('10100000', 2),
             'bitwise AND'
         )
         self.assertEqual(
-            parse_expression(222, 'b11110000|b10101010').get_value(TestExpression.label_values, 2),
+            parse_expression(222, 'b11110000|b10101010').get_value(labels, scopes, 2),
             int('11111010', 2), 'bitwise OR'
             )
         self.assertEqual(
-            parse_expression(222, 'b11110000^b10101010').get_value(TestExpression.label_values, 3),
+            parse_expression(222, 'b11110000^b10101010').get_value(labels, scopes, 3),
             int('01011010', 2), 'bitwise XOR'
             )
         # tests precendence order. + is of higher precednce than &
         self.assertEqual(
-            parse_expression(111, 'b0000111&$01+$10').get_value(TestExpression.label_values, 4),
+            parse_expression(111, 'b0000111&$01+$10').get_value(labels, scopes, 4),
             0x01, 'test precedence order'
         )
 
@@ -130,69 +140,73 @@ class TestExpression(unittest.TestCase):
         self.assertTrue(e4.contains_register_labels(registers), 'does contain registers, not binary prefix')
 
     def test_bit_shifting(self):
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(
-            parse_expression(111, '1 << 3').get_value(TestExpression.label_values, 1),
+            parse_expression(111, '1 << 3').get_value(labels, scopes, 1),
             8, '1 << 3 = 8'
         )
         self.assertEqual(
-            parse_expression(111, '1 << MixedCase').get_value(TestExpression.label_values, 1),
+            parse_expression(111, '1 << MixedCase').get_value(labels, scopes, 1),
             4, '1 << MixedCase = 4'
         )
         self.assertEqual(
-            parse_expression(111, '(MAX_N + 2) >> 1').get_value(TestExpression.label_values, 1),
+            parse_expression(111, '(MAX_N + 2) >> 1').get_value(labels, scopes, 1),
             11, '(MAX_N + 2) >> 1 = 11'
         )
 
         # test operation precedence
         self.assertEqual(
-            parse_expression(111, '1 << 2 + 1').get_value(TestExpression.label_values, 1),
+            parse_expression(111, '1 << 2 + 1').get_value(labels, scopes, 1),
             8,
             '1 << 2 + 1 = 8 (+ takes precedence over <<)'
         )
         self.assertEqual(
-            parse_expression(111, '(1 << 2) + 1').get_value(TestExpression.label_values, 1),
+            parse_expression(111, '(1 << 2) + 1').get_value(labels, scopes, 1),
             5,
             '(1 << 2) + 1 = 5 (+ takes precedence over <<)'
         )
 
     def test_unary_byte_value_extractor(self):
         line_id = LineIdentifier(777, 'test_unary_byte_value_extractor')
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
 
         self.assertEqual(
-            parse_expression(line_id, 'LSB( $1234 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'LSB( $1234 )').get_value(labels, scopes, 1),
             0x34, 'LSB( $1234 ) = $34'
         )
         self.assertEqual(
-            parse_expression(line_id, 'BYTE1( $1234 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'BYTE1( $1234 )').get_value(labels, scopes, 1),
             0x12, 'BYTE1( $1234 ) = $12'
         )
         self.assertEqual(
-            parse_expression(line_id, 'BYTE1( (MAX_N + 50)*value_1 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'BYTE1( (MAX_N + 50)*value_1 )').get_value(labels, scopes, 1),
             0x03, 'BYTE1( (MAX_N + 50)*value_1 ) = BYTE1( $0348 ) = $03'
         )
         self.assertEqual(
-            parse_expression(line_id, '4*LSB( (MAX_N + 50)*value_1 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, '4*LSB( (MAX_N + 50)*value_1 )').get_value(labels, scopes, 1),
             0x0120, '4*LSB( (MAX_N + 50)*value_1 ) = 4*LSB( $0348 ) = 4*$48 = $0120'
         )
         self.assertEqual(
-            parse_expression(line_id, 'BYTE1( $1234 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'BYTE1( $1234 )').get_value(labels, scopes, 1),
             0x12, 'BYTE1( $1234 ) = $12'
         )
         self.assertEqual(
-            parse_expression(line_id, 'BYTE1( $12345678 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'BYTE1( $12345678 )').get_value(labels, scopes, 1),
             0x56, 'BYTE1( $12345678 ) = $56'
         )
         self.assertEqual(
-            parse_expression(line_id, 'BYTE3( $12345678 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'BYTE3( $12345678 )').get_value(labels, scopes, 1),
             0x12, 'BYTE3( $12345678 ) = $12'
         )
         self.assertEqual(
             # this tests asks for a byte that exceeds the range of the value.
-            parse_expression(line_id, 'BYTE4( $12345678 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'BYTE4( $12345678 )').get_value(labels, scopes, 1),
             0, 'BYTE4( $12345678 ) = $00'
         )
         self.assertEqual(
-            parse_expression(line_id, 'BYTE2( MAX_N*MAX_N*MAX_N*MAX_N )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, 'BYTE2( MAX_N*MAX_N*MAX_N*MAX_N )').get_value(labels, scopes, 1),
             2, 'BYTE2( MAX_N*MAX_N*MAX_N*MAX_N ) = BYTE2( 0x027100 ) = 2'
         )
 
@@ -200,7 +214,7 @@ class TestExpression(unittest.TestCase):
             parse_expression(
                 line_id,
                 'BYTE0( -15 )'
-            ).get_value(TestExpression.label_values, 1),
+            ).get_value(labels, scopes, 1),
             0xF1,
             'BYTE0( -15 ) = BYTE0( 0xFFFFFFF1 ) = 0xF1'
         )
@@ -208,62 +222,68 @@ class TestExpression(unittest.TestCase):
             parse_expression(
                 line_id,
                 'BYTE1( 1000 - 2000 )'
-            ).get_value(TestExpression.label_values, 1),
+            ).get_value(labels, scopes, 1),
             0xFC,
             'BYTE1( 1000 - 2000 ) = BYTE1( 0xFFFFFC18 ) = 0xFC'
         )
 
     def test_character_ordinals_in_expressions(self):
         line_id = LineIdentifier(888, 'test_character_ordinals_in_expressions')
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
         self.assertEqual(
-            parse_expression(line_id, "'a'").get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, "'a'").get_value(labels, scopes, 1),
             97, "'a' = 97"
         )
         self.assertEqual(
-            parse_expression(line_id, "'A' + 32").get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, "'A' + 32").get_value(labels, scopes, 1),
             97, "'A' + 32 = 97"
         )
         self.assertEqual(
-            parse_expression(line_id, "(' '*32)").get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, "(' '*32)").get_value(labels, scopes, 1),
             1024, "(' '*32) = 1024"
         )
         self.assertEqual(
-            parse_expression(line_id, "(' ' + ' ')").get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, "(' ' + ' ')").get_value(labels, scopes, 1),
             64, "(' ' + ' ') = 64"
         )
 
     def test_negative_values(self):
         line_id = LineIdentifier(1927, 'test_character_ordinals_in_expressions')
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
 
         self.assertEqual(
-            parse_expression(line_id, '-21').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, '-21').get_value(labels, scopes, 1),
             -21,
             'negative 21'
         )
 
         self.assertEqual(
-            parse_expression(line_id, '5 * ( -6 )').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, '5 * ( -6 )').get_value(labels, scopes, 1),
             -30,
             'negative 30'
         )
 
         self.assertEqual(
-            parse_expression(line_id, '10 + -(5*2)').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, '10 + -(5*2)').get_value(labels, scopes, 1),
             0,
             '0'
         )
 
         self.assertEqual(
-            parse_expression(line_id, '-2*MAX_N').get_value(TestExpression.label_values, 1),
+            parse_expression(line_id, '-2*MAX_N').get_value(labels, scopes, 1),
             -40,
             'negative label expression'
         )
 
     def test_unknown_expression_parts(self):
         line_id = LineIdentifier(1928, 'test_unknown_expression_parts')
+        labels = TestExpression.label_values
+        scopes = ActiveNamedScopeList(NamedScopeManager())
 
         with self.assertRaises(SystemExit, msg='extraneous comparison operator'):
-            parse_expression(line_id, '<$2024').get_value(TestExpression.label_values, 1)
+            parse_expression(line_id, '<$2024').get_value(labels, scopes, 1)
 
 
 if __name__ == '__main__':

--- a/test/test_instruction_parsing.py
+++ b/test/test_instruction_parsing.py
@@ -5,6 +5,8 @@ from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.label_scope import GlobalLabelScope
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.assembler.label_scope import LabelScopeType
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object import LineWithWords
@@ -32,6 +34,7 @@ class TestInstructionParsing(unittest.TestCase):
         local_scope.set_label_value('.local_var', 10, 3)
         local_scope.set_label_value('.loop', 0x8020, 3)
         cls.label_values = local_scope
+        cls.active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
 
     def setUp(self):
         InstructionLine._INSTRUCTUION_EXTRACTION_PATTERN = None
@@ -436,6 +439,7 @@ class TestInstructionParsing(unittest.TestCase):
             isa_model.default_origin,
             isa_model.predefined_memory_zones,
         )
+        active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
 
         lineid = LineIdentifier(42, 'test_label_parsing')
         preprocessor = Preprocessor()
@@ -445,6 +449,7 @@ class TestInstructionParsing(unittest.TestCase):
             'LABEL = %00001111',
             isa_model,
             TestInstructionParsing.label_values,
+            active_named_scopes,
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
@@ -460,6 +465,7 @@ class TestInstructionParsing(unittest.TestCase):
             '.local_label:',
             isa_model,
             TestInstructionParsing.label_values,
+            active_named_scopes,
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
@@ -477,6 +483,7 @@ class TestInstructionParsing(unittest.TestCase):
             'old_style EQU 42H',
             isa_model,
             TestInstructionParsing.label_values,
+            active_named_scopes,
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
@@ -631,6 +638,7 @@ class TestInstructionParsing(unittest.TestCase):
             isa_model.default_origin,
             isa_model.predefined_memory_zones,
         )
+        active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
 
         lineid = LineIdentifier(33, 'test_numeric_bytecode_operand')
 
@@ -640,6 +648,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t1.set_start_address(1)
         t1.label_scope = TestInstructionParsing.label_values
+        t1.active_named_scopes = active_named_scopes
         self.assertIsInstance(t1, InstructionLine)
         self.assertEqual(t1.word_count, 1, 'has 1 words')
         t1.generate_words()
@@ -655,6 +664,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t2.set_start_address(1)
         t2.label_scope = TestInstructionParsing.label_values
+        t2.active_named_scopes = active_named_scopes
         self.assertIsInstance(t2, InstructionLine)
         self.assertEqual(t2.word_count, 1, 'has 1 words')
         t2.generate_words()
@@ -670,6 +680,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t3.set_start_address(1)
         t3.label_scope = TestInstructionParsing.label_values
+        t3.active_named_scopes = active_named_scopes
         self.assertIsInstance(t3, InstructionLine)
         self.assertEqual(t3.word_count, 2, 'has 2 words')
         t3.generate_words()
@@ -685,6 +696,7 @@ class TestInstructionParsing(unittest.TestCase):
                 isa_model, memzone_mngr.global_zone, memzone_mngr,
             )
             e1.label_scope = TestInstructionParsing.label_values
+            e1.active_named_scopes = active_named_scopes
             e1.generate_words()
 
         with self.assertRaises(SystemExit, msg='test invalid enumerations'):
@@ -693,6 +705,7 @@ class TestInstructionParsing(unittest.TestCase):
                 isa_model, memzone_mngr.global_zone, memzone_mngr,
             )
             e2.label_scope = TestInstructionParsing.label_values
+            e2.active_named_scopes = active_named_scopes
             e2.generate_words()
 
     def test_numeric_enumeration_operand(self):
@@ -703,7 +716,7 @@ class TestInstructionParsing(unittest.TestCase):
             isa_model.default_origin,
             isa_model.predefined_memory_zones,
         )
-
+        active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         lineid = LineIdentifier(33, 'test_numeric_enumeration_operand')
 
         t1 = InstructionLine.factory(
@@ -712,6 +725,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t1.set_start_address(1)
         t1.label_scope = TestInstructionParsing.label_values
+        t1.active_named_scopes = active_named_scopes
         self.assertIsInstance(t1, InstructionLine)
         self.assertEqual(t1.word_count, 1, 'has 1 words')
         t1.generate_words()
@@ -727,6 +741,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t2.set_start_address(1)
         t2.label_scope = TestInstructionParsing.label_values
+        t2.active_named_scopes = active_named_scopes
         self.assertIsInstance(t2, InstructionLine)
         self.assertEqual(t2.word_count, 1, 'has 1 words')
         t2.generate_words()
@@ -742,6 +757,7 @@ class TestInstructionParsing(unittest.TestCase):
                 isa_model, memzone_mngr.global_zone, memzone_mngr,
             )
             e1.label_scope = TestInstructionParsing.label_values
+            e1.active_named_scopes = active_named_scopes
             e1.generate_words()
 
     def test_expressions_in_operations(self):
@@ -1067,7 +1083,7 @@ class TestInstructionParsing(unittest.TestCase):
             isa_model.word_size,
             isa_model.word_segment_size,
         )
-        value1 = bc1.get_value(TestInstructionParsing.label_values, 0x2010, 32)
+        value1 = bc1.get_value(TestInstructionParsing.label_values, TestInstructionParsing.active_named_scopes, 0x2010, 32)
         self.assertEqual(value1, 0x2020, 'byte code should match')
 
         # now, test argument value generation with LSB slicing
@@ -1084,11 +1100,11 @@ class TestInstructionParsing(unittest.TestCase):
             isa_model.word_size,
             isa_model.word_segment_size,
         )
-        value2 = bc2.get_value(TestInstructionParsing.label_values, 0x2010, 32)
+        value2 = bc2.get_value(TestInstructionParsing.label_values, TestInstructionParsing.active_named_scopes, 0x2010, 32)
         self.assertEqual(value2, 0x45, 'byte code should match')
 
         with self.assertRaises(ValueError, msg="address MSBs don't match"):
-            bc2.get_value(TestInstructionParsing.label_values, 0x2250, 32)
+            bc2.get_value(TestInstructionParsing.label_values, TestInstructionParsing.active_named_scopes, 0x2250, 32)
 
         # test 16-bit slize with a 32-bit address
         bc3 = AddressByteCodePart(
@@ -1104,10 +1120,10 @@ class TestInstructionParsing(unittest.TestCase):
             isa_model.word_size,
             isa_model.word_segment_size,
         )
-        value3 = bc3.get_value(TestInstructionParsing.label_values, 0x19451000, 32)
+        value3 = bc3.get_value(TestInstructionParsing.label_values, TestInstructionParsing.active_named_scopes, 0x19451000, 32)
         self.assertEqual(value3, 0x8899, 'byte code should match')
         with self.assertRaises(ValueError, msg="address MSBs don't match"):
-            bc3.get_value(TestInstructionParsing.label_values, 0x20241000, 32)
+            bc3.get_value(TestInstructionParsing.label_values, TestInstructionParsing.active_named_scopes, 0x20241000, 32)
 
         #  test error conditions
         # error case: extraneous comparison operators ignored
@@ -1133,6 +1149,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t1.set_start_address(0x2F10)
         t1.label_scope = TestInstructionParsing.label_values
+        t1.active_named_scopes = TestInstructionParsing.active_named_scopes
         self.assertIsInstance(t1, InstructionLine)
         self.assertEqual(t1.word_count, 2, 'has 2 words')
         t1.generate_words()
@@ -1157,6 +1174,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t2.set_start_address(0x2F10)
         t2.label_scope = TestInstructionParsing.label_values
+        t2.active_named_scopes = TestInstructionParsing.active_named_scopes
         self.assertIsInstance(t2, InstructionLine)
         self.assertEqual(t2.word_count, 3, 'has 3 words')
         t2.generate_words()
@@ -1177,6 +1195,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t3.set_start_address(0x2F10)
         t3.label_scope = TestInstructionParsing.label_values
+        t3.active_named_scopes = TestInstructionParsing.active_named_scopes
         self.assertIsInstance(t3, InstructionLine)
         self.assertEqual(t3.word_count, 3, 'has 3 words')
         t3.generate_words()
@@ -1197,6 +1216,7 @@ class TestInstructionParsing(unittest.TestCase):
         )
         t4.set_start_address(0x2F10)
         t4.label_scope = TestInstructionParsing.label_values
+        t4.active_named_scopes = TestInstructionParsing.active_named_scopes
         self.assertIsInstance(t4, InstructionLine)
         self.assertEqual(t4.word_count, 3, 'has 3 words')
         with self.assertRaises(SystemExit, msg='address not in target memory zone'):

--- a/test/test_label_scope.py
+++ b/test/test_label_scope.py
@@ -6,6 +6,7 @@ from bespokeasm.assembler.assembly_file import AssemblyFile
 from bespokeasm.assembler.label_scope import GlobalLabelScope
 from bespokeasm.assembler.label_scope import LabelScope
 from bespokeasm.assembler.label_scope import LabelScopeType
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object.instruction_line import InstructionLine
@@ -118,9 +119,9 @@ class TestLabelScope(unittest.TestCase):
             isa_model.predefined_memory_zones
         )
         preprocessor = Preprocessor()
-
+        named_scope_manager = NamedScopeManager()
         asm_fp = pkg_resources.files(test_code).joinpath('test_line_object_scope_assignment.asm')
-        asm_obj = AssemblyFile(asm_fp, label_scope)
+        asm_obj = AssemblyFile(asm_fp, label_scope, named_scope_manager)
 
         try:
             line_objs: list[LineObject] = asm_obj.load_line_objects(

--- a/test/test_memory_zones.py
+++ b/test/test_memory_zones.py
@@ -3,6 +3,8 @@ import unittest
 
 from bespokeasm.assembler.assembly_file import AssemblyFile
 from bespokeasm.assembler.label_scope import GlobalLabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
+from bespokeasm.assembler.line_object.instruction_line import InstructionLine
 from bespokeasm.assembler.memory_zone import MemoryZone
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.model import AssemblerModel
@@ -14,7 +16,7 @@ from test import test_code
 
 class TestMemoryZones(unittest.TestCase):
     def setUp(self):
-        pass
+        InstructionLine.reset_instruction_pattern_cache()
 
     def test_memory_zone_obj(self):
         z1 = MemoryZone(16, 0, 0x7FFF, 'test_zone_1')
@@ -31,11 +33,12 @@ class TestMemoryZones(unittest.TestCase):
             isa_model.predefined_memory_zones
         )
         preprocessor = Preprocessor()
+        named_scope_manager = NamedScopeManager()
         self.assertEqual(memzone_manager.global_zone.start, 0x0100, 'global zone starts at $0100')
         self.assertEqual(memzone_manager.global_zone.end, 0xDFFF, 'global zone ends at $DFFF')
 
         asm_fp = pkg_resources.files(test_code).joinpath('test_memory_zones.asm')
-        asm_obj = AssemblyFile(asm_fp, label_scope)
+        asm_obj = AssemblyFile(asm_fp, label_scope, named_scope_manager)
 
         line_objs = asm_obj.load_line_objects(
             isa_model,

--- a/test/test_named_scope_directives.py
+++ b/test/test_named_scope_directives.py
@@ -1,0 +1,221 @@
+import unittest
+
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
+from bespokeasm.assembler.line_identifier import LineIdentifier
+from bespokeasm.assembler.line_object.preprocessor_line.create_scope import CreateScopeLine
+from bespokeasm.assembler.line_object.preprocessor_line.deactivate_scope import DeactivateScopeLine
+from bespokeasm.assembler.line_object.preprocessor_line.use_scope import UseScopeLine
+from bespokeasm.assembler.memory_zone import MemoryZone
+
+
+class TestNamedScopeDirectives(unittest.TestCase):
+
+    def setUp(self):
+        self.named_scope_manager = NamedScopeManager()
+        self.line_id = LineIdentifier(1, 'test.asm')
+        self.memzone = MemoryZone(16, 0, 1000, 'test')  # address_bits, start, end, name
+        # Create a minimal ISA model for testing
+        self.isa_model = None  # We'll mock this as needed
+
+    def test_create_scope_line_basic(self):
+        """Test CreateScopeLine with basic syntax."""
+        instruction = '#create-scope "test_scope" prefix="ts_"'
+
+        line = CreateScopeLine(
+            self.line_id,
+            instruction,
+            '',
+            self.memzone,
+            self.isa_model,
+            self.named_scope_manager,
+            0
+        )
+
+        self.assertEqual(line.scope_name, 'test_scope')
+        self.assertEqual(line.prefix, 'ts_')
+
+        # Verify it was added to the manager
+        definition = self.named_scope_manager.get_scope_definition('test_scope')
+        self.assertIsNotNone(definition)
+        self.assertEqual(definition.prefix, 'ts_')
+
+    def test_create_scope_line_default_prefix(self):
+        """Test CreateScopeLine with default prefix."""
+        instruction = '#create-scope "test_scope"'
+
+        line = CreateScopeLine(
+            self.line_id,
+            instruction,
+            '',
+            self.memzone,
+            self.isa_model,
+            self.named_scope_manager,
+            0
+        )
+
+        self.assertEqual(line.scope_name, 'test_scope')
+        self.assertEqual(line.prefix, '_')
+
+    def test_create_scope_line_invalid_syntax(self):
+        """Test CreateScopeLine with invalid syntax."""
+        instruction = '#create-scope invalid syntax'
+
+        with self.assertRaises(SystemExit):
+            CreateScopeLine(
+                self.line_id,
+                instruction,
+                '',
+                self.memzone,
+                self.isa_model,
+                self.named_scope_manager,
+                0
+            )
+
+    def test_create_scope_line_empty_name(self):
+        """Test CreateScopeLine with empty scope name."""
+        instruction = '#create-scope ""'
+
+        with self.assertRaises(SystemExit):
+            CreateScopeLine(
+                self.line_id,
+                instruction,
+                '',
+                self.memzone,
+                self.isa_model,
+                self.named_scope_manager,
+                0
+            )
+
+    def test_create_scope_line_period_prefix_error(self):
+        """Test CreateScopeLine with period prefix is rejected."""
+        instruction = '#create-scope "bad_scope" prefix=".invalid"'
+
+        with self.assertRaises(SystemExit):
+            CreateScopeLine(
+                self.line_id,
+                instruction,
+                '',
+                self.memzone,
+                self.isa_model,
+                self.named_scope_manager,
+                0
+            )
+
+    def test_use_scope_line_basic(self):
+        """Test UseScopeLine with defined scope."""
+        # First create the scope
+        self.named_scope_manager.create_scope('test_scope', 'ts_', self.line_id)
+
+        instruction = '#use-scope "test_scope"'
+
+        line = UseScopeLine(
+            self.line_id,
+            instruction,
+            '',
+            self.memzone,
+            self.isa_model,
+            self.named_scope_manager,
+            'test.asm',
+            0
+        )
+
+        self.assertEqual(line.scope_name, 'test_scope')
+        self.assertEqual(line.filename, 'test.asm')
+
+    def test_use_scope_line_invalid_syntax(self):
+        """Test UseScopeLine with invalid syntax."""
+        instruction = '#use-scope invalid'
+
+        with self.assertRaises(SystemExit):
+            UseScopeLine(
+                self.line_id,
+                instruction,
+                '',
+                self.memzone,
+                self.isa_model,
+                self.named_scope_manager,
+                'test.asm',
+                0
+            )
+
+    def test_deactivate_scope_line_basic(self):
+        """Test DeactivateScopeLine with active scope."""
+        # Create and activate scope
+        self.named_scope_manager.create_scope('test_scope', 'ts_', self.line_id)
+
+        instruction = '#deactivate-scope "test_scope"'
+
+        line = DeactivateScopeLine(
+            self.line_id,
+            instruction,
+            '',
+            self.memzone,
+            self.isa_model,
+            self.named_scope_manager,
+            'test.asm',
+            0
+        )
+
+        self.assertEqual(line.scope_name, 'test_scope')
+
+    def test_deactivate_scope_line_invalid_syntax(self):
+        """Test DeactivateScopeLine with invalid syntax."""
+        instruction = '#deactivate-scope invalid'
+
+        with self.assertRaises(SystemExit):
+            DeactivateScopeLine(
+                self.line_id,
+                instruction,
+                '',
+                self.memzone,
+                self.isa_model,
+                self.named_scope_manager,
+                'test.asm',
+                0
+            )
+
+    def test_complete_workflow(self):
+        """Test a complete workflow with all three directives."""
+        # Create scope
+        CreateScopeLine(
+            self.line_id,
+            '#create-scope "graphics" prefix="gfx_"',
+            '',
+            self.memzone,
+            self.isa_model,
+            self.named_scope_manager,
+            0
+        )
+
+        # Use scope
+        UseScopeLine(
+            LineIdentifier(2, 'test.asm'),
+            '#use-scope "graphics"',
+            '',
+            self.memzone,
+            self.isa_model,
+            self.named_scope_manager,
+            'test.asm',
+            0
+        )
+
+        # Deactivate scope
+        DeactivateScopeLine(
+            LineIdentifier(3, 'test.asm'),
+            '#deactivate-scope "graphics"',
+            '',
+            self.memzone,
+            self.isa_model,
+            self.named_scope_manager,
+            'test.asm',
+            0
+        )
+
+        # But scope definition should still exist
+        definition = self.named_scope_manager.get_scope_definition('graphics')
+        self.assertIsNotNone(definition)
+        self.assertEqual(definition.prefix, 'gfx_')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_named_scope_file_restrictions.py
+++ b/test/test_named_scope_file_restrictions.py
@@ -1,0 +1,284 @@
+"""
+Test suite for named scope file restrictions and advanced behaviors.
+
+This test module demonstrates and validates:
+1. Labels can only be created into a named scope in the same file where scope is created
+2. Forward references (using scope before it's defined) are supported and intentional
+3. Underscore prefix behavior for "exporting" what would normally be file-local symbols
+"""
+import importlib.resources as pkg_resources
+import os
+import shutil
+import tempfile
+import unittest
+
+from bespokeasm.assembler.engine import Assembler
+from bespokeasm.assembler.line_object.instruction_line import InstructionLine
+
+from test import config_files
+
+
+class TestNamedScopeFileRestrictions(unittest.TestCase):
+    """Test that labels can only be created into named scopes in the same file as scope creation."""
+
+    def setUp(self):
+        # Reset instruction pattern cache for test isolation
+        InstructionLine.reset_instruction_pattern_cache()
+
+        self.config_file = str(pkg_resources.files(config_files).joinpath('test_instruction_operands.yaml'))
+        self.test_code_dir = os.path.join(tempfile.gettempdir(), 'test_named_scope_restrictions')
+        os.makedirs(self.test_code_dir, exist_ok=True)
+
+    def tearDown(self):
+        # Clean up temporary directory and all its contents
+        if os.path.exists(self.test_code_dir):
+            shutil.rmtree(self.test_code_dir)
+
+    def test_labels_only_created_in_scope_defining_file(self):
+        """Test that labels with named scope prefix are only added to named scope in the defining file.
+
+        This test verifies that:
+        - Labels in the library file (where scope is created) go into the named scope
+        - Labels in the main file (where scope is only used) do NOT go into the named scope
+        - Labels in the main file fall back to global scope even if they match the prefix
+        """
+
+        library_content = '''
+; Library file that defines the scope
+#create-scope "mylib" prefix="lib_"
+
+; These labels should go into the mylib named scope
+lib_init: .byte 1
+lib_version: .byte 2
+lib_constant = 100
+'''
+
+        main_content = '''
+; Main file that uses the scope but doesn't define it
+#use-scope "mylib"
+
+#include "test_library.asm"
+
+; This label has the lib_ prefix but should NOT go into mylib scope
+; because this file didn't create the scope
+; It should fall back to global scope
+lib_custom_main: .byte 3
+
+; Simple instruction to complete the assembly
+ld a, b, c
+'''
+
+        # Write files
+        lib_file = os.path.join(self.test_code_dir, 'test_library.asm')
+        main_file = os.path.join(self.test_code_dir, 'test_main.asm')
+
+        with open(lib_file, 'w') as f:
+            f.write(library_content)
+        with open(main_file, 'w') as f:
+            f.write(main_content)
+
+        # Create and run assembler - should succeed
+        assembler = Assembler(
+            source_file=main_file,
+            config_file=self.config_file,
+            generate_binary=False,
+            output_file=None,
+            binary_start=None,
+            binary_end=None,
+            binary_fill_value=0,  # Default fill value
+            enable_pretty_print=False,
+            pretty_print_format=None,
+            pretty_print_output=None,
+            is_verbose=0,
+            include_paths=[self.test_code_dir],
+            predefined=[],
+        )
+
+        # This should succeed - labels fall back to global scope
+        assembler.assemble_bytecode()
+        self.assertTrue(True, 'Assembly completed - file restriction working correctly')
+
+    def test_forward_references_are_supported(self):
+        """Test that scopes can be used before they are defined (forward references).
+
+        This is an intentional feature to support library workflows where a main file
+        declares dependencies at the top, then includes library files later.
+        """
+
+        library_content = '''
+; Library file that defines the scope
+#create-scope "graphics" prefix="gfx_"
+
+; Library functions
+gfx_init: .byte 100
+gfx_clear: .byte 200
+'''
+
+        main_content = '''
+; Main file uses scope BEFORE including the library that defines it
+; This is intentional and should work
+#use-scope "graphics"
+
+; These will fall back to global since scope not created in this file
+gfx_buffer: .2byte 640
+
+; Now include the library that actually creates the scope
+#include "test_graphics_lib.asm"
+
+; Simple instruction to complete assembly
+ld a, b, c
+'''
+
+        # Write files
+        lib_file = os.path.join(self.test_code_dir, 'test_graphics_lib.asm')
+        main_file = os.path.join(self.test_code_dir, 'test_main_forward.asm')
+
+        with open(lib_file, 'w') as f:
+            f.write(library_content)
+        with open(main_file, 'w') as f:
+            f.write(main_content)
+
+        # Create and run assembler
+        assembler = Assembler(
+            source_file=main_file,
+            config_file=self.config_file,
+            generate_binary=False,
+            output_file=None,
+            binary_start=None,
+            binary_end=None,
+            binary_fill_value=0,
+            enable_pretty_print=False,
+            pretty_print_format=None,
+            pretty_print_output=None,
+            is_verbose=0,
+            include_paths=[self.test_code_dir],
+            predefined=[],
+        )
+
+        # This should succeed - forward references are supported
+        assembler.assemble_bytecode()
+        self.assertTrue(True, 'Assembly completed with forward reference - working as designed')
+
+    def test_underscore_prefix_exports_file_local_symbols(self):
+        """Test that underscore prefix can be used to export what would be file-local symbols.
+
+        When a library creates a named scope with underscore prefix, it allows the library
+        to "export" symbols that would normally be file-local only. This is useful for
+        library APIs that want to use underscore convention without limiting visibility.
+        """
+
+        library_content = '''
+; Library uses underscore as prefix to "export" internal symbols
+#create-scope "mathlib" prefix="_"
+
+; These would normally be file-local but go to mathlib named scope instead
+_multiply: .byte 100
+_divide: .byte 200
+_internal_state: .byte 0
+'''
+
+        main_content = '''
+; Main file activates the mathlib scope
+#use-scope "mathlib"
+
+#include "test_mathlib.asm"
+
+; This underscore-prefixed label will NOT go to mathlib scope (wrong file)
+; But since mathlib scope takes precedence, it falls back to global scope
+_local_var: .byte 50
+
+; Simple instruction
+ld a, b, c
+'''
+
+        # Write files
+        lib_file = os.path.join(self.test_code_dir, 'test_mathlib.asm')
+        main_file = os.path.join(self.test_code_dir, 'test_main_underscore.asm')
+
+        with open(lib_file, 'w') as f:
+            f.write(library_content)
+        with open(main_file, 'w') as f:
+            f.write(main_content)
+
+        # Create and run assembler
+        assembler = Assembler(
+            source_file=main_file,
+            config_file=self.config_file,
+            generate_binary=False,
+            output_file=None,
+            binary_start=None,
+            binary_end=None,
+            binary_fill_value=0,
+            enable_pretty_print=False,
+            pretty_print_format=None,
+            pretty_print_output=None,
+            is_verbose=0,
+            include_paths=[self.test_code_dir],
+            predefined=[],
+        )
+
+        # This should succeed - underscore labels in different files fall back to global
+        assembler.assemble_bytecode()
+        self.assertTrue(True, 'Assembly completed - underscore prefix export working')
+
+    def test_constants_respect_file_restriction(self):
+        """Test that constants also respect the file restriction for named scopes.
+
+        Like address labels, constants can only be added to a named scope in the file
+        where that scope was created.
+        """
+
+        library_content = '''
+; Library defines scope and constants
+#create-scope "config" prefix="cfg_"
+
+cfg_max_size = 1024
+cfg_default_mode = 2
+'''
+
+        main_content = '''
+; Main file tries to define constants with same prefix
+#use-scope "config"
+
+; This constant will NOT go to config scope (wrong file)
+; Falls back to global scope
+cfg_custom_value = 999
+
+#include "test_config_lib.asm"
+
+ld a, b, c
+'''
+
+        # Write files
+        lib_file = os.path.join(self.test_code_dir, 'test_config_lib.asm')
+        main_file = os.path.join(self.test_code_dir, 'test_main_constants.asm')
+
+        with open(lib_file, 'w') as f:
+            f.write(library_content)
+        with open(main_file, 'w') as f:
+            f.write(main_content)
+
+        # Create and run assembler
+        assembler = Assembler(
+            source_file=main_file,
+            config_file=self.config_file,
+            generate_binary=False,
+            output_file=None,
+            binary_start=None,
+            binary_end=None,
+            binary_fill_value=0,
+            enable_pretty_print=False,
+            pretty_print_format=None,
+            pretty_print_output=None,
+            is_verbose=0,
+            include_paths=[self.test_code_dir],
+            predefined=[],
+        )
+
+        # This should succeed - constants in wrong file fall back to global scope
+        assembler.assemble_bytecode()
+        self.assertTrue(True, 'Assembly completed - constant file restriction working')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_named_scope_isolation.py
+++ b/test/test_named_scope_isolation.py
@@ -1,0 +1,218 @@
+import importlib.resources as pkg_resources
+import os
+import shutil
+import tempfile
+import unittest
+
+from bespokeasm.assembler.assembly_file import AssemblyFile
+from bespokeasm.assembler.label_scope import LabelScopeType
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
+from bespokeasm.assembler.line_object.instruction_line import InstructionLine
+from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
+from bespokeasm.assembler.model import AssemblerModel
+from bespokeasm.assembler.preprocessor import Preprocessor
+
+from test import config_files
+
+
+class TestNamedScopeIsolation(unittest.TestCase):
+    """Test proper isolation of named scope labels - they should only be accessible when scope is active."""
+
+    def setUp(self):
+        # Reset instruction pattern cache for test isolation
+        InstructionLine.reset_instruction_pattern_cache()
+
+        self.config_file = str(pkg_resources.files(config_files).joinpath('test_instruction_operands.yaml'))
+        self.test_code_dir = os.path.join(tempfile.gettempdir(), 'test_code')
+        os.makedirs(self.test_code_dir, exist_ok=True)
+
+        # Create the assembler model
+        self.isa_model = AssemblerModel(self.config_file, 0)
+
+        # Create named scope manager
+        self.named_scope_manager = NamedScopeManager()
+
+        # Create global label scope with named scope manager
+        self.global_scope = self.isa_model.global_label_scope
+
+        # Create memory zone manager
+        self.memzone_manager = MemoryZoneManager(
+            self.isa_model.address_size,
+            self.isa_model.default_origin,
+            self.isa_model.predefined_memory_zones,
+        )
+
+        # Create preprocessor
+        self.preprocessor = Preprocessor(self.isa_model.predefined_symbols)
+
+    def tearDown(self):
+        # Clean up temporary directory and all its contents
+        if os.path.exists(self.test_code_dir):
+            shutil.rmtree(self.test_code_dir)
+
+    def test_named_scope_labels_should_be_isolated_when_scope_inactive(self):
+        """Test that labels with named scope prefixes are not accessible when scope is not active."""
+
+        # This test replicates the mandelbrot bug:
+        # 1. Library defines a scope and labels with that scope's prefix
+        # 2. Main file does NOT activate the scope
+        # 3. Main file should NOT be able to access the scope's labels
+
+        main_content = '''
+; Main file that does NOT use the mathlib16 scope
+; This should fail to resolve ml16_signed_multiply
+
+; Comment out the use-scope directive to replicate the bug
+; #use-scope "mathlib16"
+
+; Include the library that defines the scope and its labels FIRST
+; so that the labels exist when we try to use them
+#include "temp_isolated_mathlib.asm"
+
+; Try to use a function from the mathlib16 scope - this should FAIL
+main_function: .byte 42
+
+; This should fail because mathlib16 scope is not active in this file
+; ml16_signed_multiply is defined with "ml16_" prefix in library
+; Use .2byte directive to reference the label - this should cause scope isolation error
+jmp ml16_signed_multiply
+
+ld a, b, c
+'''
+
+        library_content = '''
+; Library file that defines named scope and labels with scope prefix
+#create-scope "mathlib16" prefix="ml16_"
+#use-scope "mathlib16"
+
+; This label has the ml16_ prefix and should only be accessible
+; when the mathlib16 scope is active
+ml16_signed_multiply: .byte 200
+
+; This is a global label and should always be accessible
+global_math_function: .byte 100
+
+; this is a file local symbol
+_file_local_label: .byte 10
+'''
+
+        # Write both files
+        main_file = os.path.join(self.test_code_dir, 'temp_isolation_main.asm')
+        lib_file = os.path.join(self.test_code_dir, 'temp_isolated_mathlib.asm')
+
+        with open(main_file, 'w') as f:
+            f.write(main_content)
+        with open(lib_file, 'w') as f:
+            f.write(library_content)
+
+        # Create assembly file
+        asm_file = AssemblyFile(main_file, self.global_scope, self.named_scope_manager)
+
+        # Load line objects
+        include_paths = {self.test_code_dir}
+
+        # This should FAIL because ml16_signed_multiply should not be resolvable
+        # when the mathlib16 scope is not active
+        line_objects = asm_file.load_line_objects(
+                self.isa_model,
+                include_paths,
+                self.memzone_manager,
+                self.preprocessor,
+                2  # log_verbosity
+            )
+        print('DEBUG - load_line_objects completed successfully')
+
+        # Verify that the mathlib16 scope was properly created and used
+        mathlib_def = self.named_scope_manager.get_scope_definition('mathlib16')
+        self.assertIsNotNone(mathlib_def)
+        self.assertEqual(mathlib_def.prefix, 'ml16_')
+
+        for lobj in line_objects:
+            # look for the `jmp` instruction
+            if isinstance(lobj, InstructionLine) and lobj.instruction == 'jmp ml16_signed_multiply':
+                # assert label scope is local and there are no active named scopes
+                self.assertEqual(lobj.label_scope.type, LabelScopeType.LOCAL)
+                self.assertEqual(lobj.active_named_scopes, [])
+
+    def test_named_scope_labels_should_be_accessible_when_scope_active(self):
+        """Test that labels with named scope prefixes ARE accessible when scope is active."""
+
+        main_content = '''
+; Main file that DOES use the mathlib16 scope
+; This should succeed in resolving ml16_signed_multiply
+
+; Activate the scope
+#use-scope "mathlib16"
+
+; Try to use a function from the mathlib16 scope - this should SUCCEED
+main_function:
+    adi 42
+
+    ; This should work because mathlib16 scope is active
+    jmp ml16_signed_multiply    ; Should resolve successfully
+
+    adi 100
+
+; Include the library that defines the scope and its labels
+#include "temp_accessible_mathlib.asm"
+
+ld a, b, c
+'''
+
+        library_content = '''
+; Library file that defines named scope and labels with scope prefix
+#create-scope "mathlib16" prefix="ml16_"
+#use-scope "mathlib16"
+
+; This label has the ml16_ prefix and should be accessible
+; when the mathlib16 scope is active
+ml16_signed_multiply: .byte 200
+
+; This is a global label and should always be accessible
+global_math_function: .byte 100
+
+; this is a file local symbol
+_file_local_label: .byte 10
+'''
+
+        # Write both files
+        main_file = os.path.join(self.test_code_dir, 'temp_accessible_main.asm')
+        lib_file = os.path.join(self.test_code_dir, 'temp_accessible_mathlib.asm')
+
+        with open(main_file, 'w') as f:
+            f.write(main_content)
+        with open(lib_file, 'w') as f:
+            f.write(library_content)
+
+        # Create assembly file
+        asm_file = AssemblyFile(main_file, self.global_scope, self.named_scope_manager)
+
+        # Load line objects
+        include_paths = {self.test_code_dir}
+
+        # This should SUCCEED because ml16_signed_multiply should be resolvable
+        # when the mathlib16 scope is active
+        line_objects = asm_file.load_line_objects(
+            self.isa_model,
+            include_paths,
+            self.memzone_manager,
+            self.preprocessor,
+            0  # log_verbosity
+        )
+
+        # Verify that the mathlib16 scope was properly created and used
+        mathlib_def = self.named_scope_manager.get_scope_definition('mathlib16')
+        self.assertIsNotNone(mathlib_def)
+        self.assertEqual(mathlib_def.prefix, 'ml16_')
+
+        # Verify the scope is active in the main file
+        for lobj in line_objects:
+            # look for the `jmp` instruction
+            if isinstance(lobj, InstructionLine) and lobj.instruction == 'jmp ml16_signed_multiply':
+                # assert label scope is local and there are no active named scopes
+                self.assertEqual(lobj.label_scope.type, LabelScopeType.LOCAL)
+                self.assertEqual(lobj.active_named_scopes, ['mathlib16'])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_preprocessor_symbols.py
+++ b/test/test_preprocessor_symbols.py
@@ -3,9 +3,12 @@ import unittest
 
 from bespokeasm.assembler.assembly_file import AssemblyFile
 from bespokeasm.assembler.label_scope import GlobalLabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object import LineObject
 from bespokeasm.assembler.line_object.factory import LineOjectFactory
+from bespokeasm.assembler.line_object.instruction_line import InstructionLine
 from bespokeasm.assembler.line_object.preprocessor_line.define_symbol import DefineSymbolLine
 from bespokeasm.assembler.memory_zone.manager import MemoryZoneManager
 from bespokeasm.assembler.model import AssemblerModel
@@ -25,7 +28,7 @@ from test import test_code
 
 class TestPreprocessorSymbols(unittest.TestCase):
     def setUp(self):
-        pass
+        InstructionLine.reset_instruction_pattern_cache()
 
     def test_proprocessor_resolve_symbols(self):
         preprocessor = Preprocessor()
@@ -173,6 +176,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
         )
 
         global_scope = GlobalLabelScope(set())
+        active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         lineid = LineIdentifier(12, 'test_define_symbol_line_objects')
         preprocessor = Preprocessor()
 
@@ -181,6 +185,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
             '#define TEST_SYMBOL 0x1234',
             isa_model,
             global_scope,
+            active_named_scopes,
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
@@ -201,6 +206,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
             '#define MY_NAME "George Washington!"',
             isa_model,
             global_scope,
+            active_named_scopes,
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
@@ -224,6 +230,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
             '#define WITH_COMMENT (13 + 27) ; my comment',
             isa_model,
             global_scope,
+            active_named_scopes,
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
@@ -248,6 +255,7 @@ class TestPreprocessorSymbols(unittest.TestCase):
             '#define CODE_SYMBOL push a  ; my comment',
             isa_model,
             global_scope,
+            active_named_scopes,
             memzone_mngr.global_zone,
             memzone_mngr,
             preprocessor,
@@ -273,9 +281,10 @@ class TestPreprocessorSymbols(unittest.TestCase):
             isa_model.predefined_memory_zones
         )
         preprocessor = Preprocessor()
+        named_scope_manager = NamedScopeManager()
 
         asm_fp = pkg_resources.files(test_code).joinpath('test_compilation_control.asm')
-        asm_obj = AssemblyFile(asm_fp, label_scope)
+        asm_obj = AssemblyFile(asm_fp, label_scope, named_scope_manager)
 
         try:
             line_objs: list[LineObject] = asm_obj.load_line_objects(

--- a/test/test_pretty_printing.py
+++ b/test/test_pretty_printing.py
@@ -3,6 +3,8 @@ import unittest
 
 from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.label_scope import GlobalLabelScope
+from bespokeasm.assembler.label_scope.named_scope_manager import ActiveNamedScopeList
+from bespokeasm.assembler.label_scope.named_scope_manager import NamedScopeManager
 from bespokeasm.assembler.line_identifier import LineIdentifier
 from bespokeasm.assembler.line_object.factory import LineOjectFactory
 from bespokeasm.assembler.line_object.instruction_line import InstructionLine
@@ -138,6 +140,7 @@ class TestPrettyPrinting(unittest.TestCase):
         ]
         line_objs = []
         preprocessor = Preprocessor()
+        active_named_scopes = ActiveNamedScopeList(NamedScopeManager())
         label_scope = GlobalLabelScope(set())
         for i, line in enumerate(lines, 1):
             line_obj = LineOjectFactory.parse_line(
@@ -145,6 +148,7 @@ class TestPrettyPrinting(unittest.TestCase):
                 line_str=line,
                 model=isa_model,
                 label_scope=None,
+                active_named_scopes=active_named_scopes,
                 current_memzone=memzone_mngr.global_zone,
                 memzone_manager=memzone_mngr,
                 preprocessor=preprocessor,


### PR DESCRIPTION
Added named label scopes feature. Create custom symbol namespaces with user-defined prefixes that can be shared across files. Useful for library files that want to publish access to internal labels and constants without placing them into the global namespace. Use `#create-scope "name" prefix="prefix_"`, `#use-scope "name"`, and `#deactivate-scope "name"` directives. Label and constant prefixes indicate what namespace it will be created into. Supports library workflows where scopes can be used before being defined.