### PR TITLE
Improved Address Slicing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Changes that are planned but not implemented yet:
 
 
 ## [Unreleased]
+
+## [0.7.2]
 * Added `.16byte` data directive to emit 16-byte values with configured multi-word endianness.
 * Added `#error` preprocessor directive for compile-time errors with optional message.
 * Added an enhanced instruction set for the Ben Eater SAP-1 example
@@ -28,6 +30,7 @@ Changes that are planned but not implemented yet:
 * Fixed a bug where single character ordinals with the double quote character (`'"'`) did not parse correctly.
 * Added operand labels in instruction operands using `@name: expression` for `numeric`, `indirect_numeric`, `deferred_numeric`, `address`, and `relative_address` operand types; includes scope behavior aligned with normal labels, targeted diagnostics for malformed syntax/invalid emission targets, and VS Code/Sublime/Vim highlighting + hover definition support for operand-label definitions. Operand labels are not supported in macro definitions or macro invocations.
 * Fixed bug in how the `.byte` data directive handles lists of mixed value types (styrings and numeric).
+* Updated sliced `address` operands so `match_on_argument_bytcode` is honored when `match_address_msb` is enabled, allowing page matching against the emitted operand fetch address instead of only the instruction start address.
 
 ## [0.7.1]
 * Added support to the VSCode and Sublime Text language extensions for editor hovers for mnemonics, labels, and constants; plus improved semantic syntax highlighting that differentiations label and constant defintion from label and constant usage.
@@ -213,7 +216,8 @@ First tracked released
 * Enabled the `reverse_argument_order` instruction option be applied to a specific operand configuration. This slightly changed the configuration file format.
 * Added ability for instructions with operands to have a single "empty operand" variant, e.g., `pop`
 
-[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/michaelkamprath/bespokeasm/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/michaelkamprath/bespokeasm/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/michaelkamprath/bespokeasm/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/michaelkamprath/bespokeasm/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/michaelkamprath/bespokeasm/compare/v0.5.1...v0.6.0

--- a/examples/slu4-minimal-64x4/slu4-minimal-64x4.yaml
+++ b/examples/slu4-minimal-64x4/slu4-minimal-64x4.yaml
@@ -99,7 +99,7 @@ operand_sets:
           description: Two byte address pointing two two bytes in memory that contain another address to use.
   address_lsb:
     # one byte is interpreted as an address's LSB and the address MSB
-    # is taken from the current instruction address
+    # is taken from the operand fetch page, i.e. the page containing the emitted operand byte
     operand_values:
       address_lsb:
         type: address
@@ -109,10 +109,11 @@ operand_sets:
           endian: little
           slice_lsb: true
           match_address_msb: true
+          match_on_argument_bytcode: true
         documentation:
           title: Page Offset Address
           category: addressing
-          description: One byte used as the LSB for the address. The MSB is the current instruct's address MSB.
+          description: One byte used as the LSB for the address. The MSB of the address comes from the operand's own bytecode address.
   offset:
     # one byte is interpreted as an offset
     operand_values:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bespokeasm"
-version = "0.7.2b"
+version = "0.7.2"
 authors = [
   { name="Michael Kamprath", email="michael@kamprath.net" },
 ]

--- a/src/bespokeasm/__init__.py
+++ b/src/bespokeasm/__init__.py
@@ -1,4 +1,4 @@
-BESPOKEASM_VERSION_STR = '0.7.2b'
+BESPOKEASM_VERSION_STR = '0.7.2'
 
 # if a cconfig file requires a certain bespoke ASM version, it should be at least this version.
 BESPOKEASM_MIN_REQUIRED_STR = '0.7.0'

--- a/src/bespokeasm/assembler/bytecode/assembled.py
+++ b/src/bespokeasm/assembler/bytecode/assembled.py
@@ -122,14 +122,15 @@ class AssembledInstruction:
         :returns: A list of words that represent the assembled instruction.
         '''
         words: list[Word] = ByteCodePart.compact_parts_to_words(
-            self._parts,
-            self._word_size,
-            self._segment_size,
-            self._multi_word_endian,
-            label_scope,
-            active_named_scopes,
-            instruction_address,
-            instruction_size,
+            parts=self._parts,
+            word_size=self._word_size,
+            segment_size=self._segment_size,
+            multi_word_endianness=self._multi_word_endian,
+            label_scope=label_scope,
+            active_named_scopes=active_named_scopes,
+            instruction_address=instruction_address,
+            instruction_size=instruction_size,
+            bytecode_start_address=instruction_address,
         )
         return words
 

--- a/src/bespokeasm/assembler/bytecode/parts.py
+++ b/src/bespokeasm/assembler/bytecode/parts.py
@@ -103,6 +103,7 @@ class ByteCodePart:
         _active_named_scopes: ActiveNamedScopeList,
         _instruction_address: int,
         _instruction_size: int,
+        _bytecode_address: int | None = None,
     ) -> int:
         # this should be overridden
         raise NotImplementedError
@@ -113,6 +114,7 @@ class ByteCodePart:
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> WordSlice | Value:
         return WordSlice(
             self.get_value(
@@ -120,6 +122,7 @@ class ByteCodePart:
                 active_named_scopes,
                 instruction_address,
                 instruction_size,
+                bytecode_address,
             ),
             self._value_size,
         )
@@ -130,12 +133,14 @@ class ByteCodePart:
             active_named_scopes: ActiveNamedScopeList,
             instruction_address: int,
             instruction_size: int,
+            bytecode_address: int | None = None,
     ) -> list[Word]:
         value_representation = self.get_value_representation(
             label_scope,
             active_named_scopes,
             instruction_address,
             instruction_size,
+            bytecode_address,
         )
         if isinstance(value_representation, WordSlice):
             return [
@@ -157,6 +162,23 @@ class ByteCodePart:
         return False
 
     @classmethod
+    def _iter_parts_with_bytecode_addresses(
+        cls,
+        parts: list[ByteCodePart],
+        word_size: int,
+        bytecode_start_address: int | None,
+    ):
+        bit_offset = 0
+        for part in parts:
+            if part.word_align and bit_offset % word_size != 0:
+                bit_offset += word_size - (bit_offset % word_size)
+            part_bytecode_address = None
+            if bytecode_start_address is not None:
+                part_bytecode_address = bytecode_start_address + (bit_offset // word_size)
+            yield part, part_bytecode_address
+            bit_offset += part.value_size
+
+    @classmethod
     def compact_parts_to_words(
         cls,
         parts: list[ByteCodePart],
@@ -167,6 +189,7 @@ class ByteCodePart:
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_start_address: int | None = None,
     ) -> list[Word]:
         """
         Compact a list of ByteCodePart objects into a list of Word objects.
@@ -208,7 +231,11 @@ class ByteCodePart:
                 current_word_slices = []
             return result
 
-        for part in parts:
+        for part, part_bytecode_address in cls._iter_parts_with_bytecode_addresses(
+            parts,
+            word_size,
+            bytecode_start_address,
+        ):
             if isinstance(part, CompositeByteCodePart):
                 # if the CompositeByteCodePart is word-aligned, then we flush the word slices and
                 # add the part's words. Otherwise, we get the WordSlice from the part.
@@ -220,6 +247,7 @@ class ByteCodePart:
                         active_named_scopes,
                         instruction_address,
                         instruction_size,
+                        part_bytecode_address,
                     ))
                 else:
                     value_representation = part.get_value_representation(
@@ -227,6 +255,7 @@ class ByteCodePart:
                         active_named_scopes,
                         instruction_address,
                         instruction_size,
+                        part_bytecode_address,
                     )
                     if isinstance(value_representation, WordSlice):
                         current_word_slices.append((value_representation, part.intra_word_endian))
@@ -241,6 +270,7 @@ class ByteCodePart:
                     active_named_scopes,
                     instruction_address,
                     instruction_size,
+                    part_bytecode_address,
                 )
                 if isinstance(value_representation, WordSlice):
                     if part.word_align:
@@ -307,6 +337,7 @@ class NumericByteCodePart(ByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
         return self._value
 
@@ -348,6 +379,7 @@ class ExpressionByteCodePart(ByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
         value = self._parsed_expression.get_value(
             label_scope,
@@ -398,8 +430,15 @@ class ExpressionByteCodePartWithValidation(ExpressionByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
-        value = super().get_value(label_scope, active_named_scopes, instruction_address, instruction_size)
+        value = super().get_value(
+            label_scope,
+            active_named_scopes,
+            instruction_address,
+            instruction_size,
+            bytecode_address,
+        )
         if self._max is not None and value > self._max:
             sys.exit(f'ERROR: {self.line_id} - operand value of {value} exceeds maximun allowed of {self._max}')
         if self._min is not None and value < self._min:
@@ -441,8 +480,15 @@ class ExpressionByteCodePartInMemoryZone(ExpressionByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
-        value = super().get_value(label_scope, active_named_scopes, instruction_address, instruction_size)
+        value = super().get_value(
+            label_scope,
+            active_named_scopes,
+            instruction_address,
+            instruction_size,
+            bytecode_address,
+        )
         if self._memzone is not None:
             if value > self._memzone.end:
                 sys.exit(
@@ -494,8 +540,15 @@ class ExpressionEnumerationByteCodePart(ExpressionByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
-        value = super().get_value(label_scope, active_named_scopes, instruction_address, instruction_size)
+        value = super().get_value(
+            label_scope,
+            active_named_scopes,
+            instruction_address,
+            instruction_size,
+            bytecode_address,
+        )
         if value not in self._value_dict:
             sys.exit(
                 f'ERROR: {self.line_id} - numeric expression value of {value} is '
@@ -547,17 +600,23 @@ class CompositeByteCodePart(ByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
         bits = PackedBits()
-        for p in self._parts_list:
+        for part, part_bytecode_address in self._iter_parts_with_bytecode_addresses(
+            self._parts_list,
+            self.word_size,
+            bytecode_address,
+        ):
             bits.append_bits(
-                p.get_value(
+                part.get_value(
                     label_scope,
                     active_named_scopes,
                     instruction_address,
                     instruction_size,
+                    part_bytecode_address,
                 ),
-                p.value_size,
+                part.value_size,
                 False,
             )
         value = int.from_bytes(bits.get_bytes(), 'big')
@@ -572,12 +631,19 @@ class CompositeByteCodePart(ByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> WordSlice | Value:
         '''
         For a CompositeByteCodePart, we will return a compacted WordSlice based on the compacted value
         '''
         return WordSlice(
-            self.get_value(label_scope, active_named_scopes, instruction_address, instruction_size),
+            self.get_value(
+                label_scope,
+                active_named_scopes,
+                instruction_address,
+                instruction_size,
+                bytecode_address,
+            ),
             self.value_size,
         )
 
@@ -587,6 +653,7 @@ class CompositeByteCodePart(ByteCodePart):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> list[Word]:
         """
         Returns a list of Word objects representing the composite bytecode part.
@@ -601,4 +668,5 @@ class CompositeByteCodePart(ByteCodePart):
             active_named_scopes,
             instruction_address,
             instruction_size,
+            bytecode_address,
         )

--- a/src/bespokeasm/assembler/model/operand/types/address.py
+++ b/src/bespokeasm/assembler/model/operand/types/address.py
@@ -4,8 +4,8 @@
 # - The bytecode of the argument value (the address) can be sliced into the least significant byte(s),
 #   to enable "fast jumps" in the assembler.
 #   * The expected significant bytes can either be configured to a specific value (e.g., "zero page")
-#     or to the same as the current instruction's address. If the operand's value has a signficant byte(s)
-#     that is not what is expected, the assembler will raise an error.
+#     or to match either the current instruction address or the emitted operand fetch page. If the
+#     operand's value has significant byte(s) that are not what is expected, the assembler raises an error.
 from bespokeasm.assembler.bytecode.parts import ExpressionByteCodePartInMemoryZone
 from bespokeasm.assembler.bytecode.parts import NumericByteCodePart
 from bespokeasm.assembler.label_scope import LabelScope
@@ -31,12 +31,13 @@ class AddressByteCodePart(ExpressionByteCodePartInMemoryZone):
         memzone: MemoryZone,
         is_lsb_bytes: bool,
         match_address_msb: bool,
+        match_on_argument_bytcode: bool,
         word_size: int,
         word_segment_size: int,
     ) -> None:
         """Creates a new address bytecode part that is bound to a memory zone.
            The address value is sliced into the least significant bit(s) if `is_lsb_bytes` is true,
-           ensuring that the MSBs match the current instruction's address MSBs."""
+           ensuring that the MSBs match the configured comparison page."""
         super().__init__(
             memzone,
             value_expression,
@@ -50,10 +51,12 @@ class AddressByteCodePart(ExpressionByteCodePartInMemoryZone):
         )
         self._is_lsb_bytes = is_lsb_bytes
         self._match_address_msb = match_address_msb
+        self._match_on_argument_bytcode = match_on_argument_bytcode
 
     def __str__(self) -> str:
         return f'AddressByteCodePart<expression="{self._expression}",zone={self._memzone},' \
-               f'slice_lab={self._is_lsb_bytes},match_msb={self._match_address_msb}>'
+               f'slice_lab={self._is_lsb_bytes},match_msb={self._match_address_msb},' \
+               f'match_on_arg_bytecode={self._match_on_argument_bytcode}>'
 
     def get_value(
         self,
@@ -61,6 +64,7 @@ class AddressByteCodePart(ExpressionByteCodePartInMemoryZone):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
         if instruction_address is None:
             raise ValueError('AddressByteCodePart.get_value had no instruction_address passed')
@@ -69,19 +73,26 @@ class AddressByteCodePart(ExpressionByteCodePartInMemoryZone):
             active_named_scopes,
             instruction_address,
             instruction_size,
+            bytecode_address,
         )
 
         if self._is_lsb_bytes and self._match_address_msb:
             # mask out the MSBs of the address value. The`value_size` is interpreted as the number of LSB bytes
             mask = (1 << self.value_size) - 1
             final_value = value & mask
-            # check if the MSBs of the value match the MSBs of the instruction address
-            shifted_address = instruction_address >> self.value_size
+            if self._match_on_argument_bytcode and bytecode_address is None:
+                raise ValueError('AddressByteCodePart.get_value had no bytecode_address passed')
+            operand_byte_address = instruction_address if bytecode_address is None else bytecode_address
+            comparison_address = operand_byte_address if self._match_on_argument_bytcode else instruction_address
+            # check if the MSBs of the value match the configured comparison address
+            shifted_address = comparison_address >> self.value_size
             shifted_value = value >> self.value_size
             if shifted_address != shifted_value:
                 raise ValueError(
-                    f'Operand address value 0x{value:x} does not have the same MSBs '
-                    f'as the instruction address 0x{instruction_address:x}'
+                    f'Target address 0x{value:x} does not have the same MSBs '
+                    f'as page comparison address 0x{comparison_address:x} '
+                    f'(instruction address 0x{instruction_address:x}, '
+                    f'operand byte address 0x{operand_byte_address:x})'
                 )
         else:
             final_value = value
@@ -143,10 +154,17 @@ class AddressOperand(NumericExpressionOperand):
 
     @property
     def match_address_msb(self) -> bool:
-        """Returns true if the argument value's MSBs should match the MSBs of the current instruction's
-           address. Can only be true if `does_lsb_slice` is also true. Defaults to false."""
+        """Returns true if the argument value's MSBs should match the configured comparison page.
+           Can only be true if `does_lsb_slice` is also true. Defaults to false."""
         if self.does_lsb_slice:
             return self.config['argument'].get('match_address_msb', False)
+        return False
+
+    @property
+    def match_on_argument_bytcode(self) -> bool:
+        """Returns true if MSB matching should use the emitted address of the operand bytes."""
+        if self.does_lsb_slice and self.match_address_msb:
+            return self.config['argument'].get('match_on_argument_bytcode', False)
         return False
 
     def _parse_bytecode_parts(
@@ -179,6 +197,7 @@ class AddressOperand(NumericExpressionOperand):
             self.valid_memory_zone(memzone_manager),
             self.does_lsb_slice,
             self.match_address_msb,
+            self.match_on_argument_bytcode,
             self._word_size,
             self._word_segment_size,
         )

--- a/src/bespokeasm/assembler/model/operand/types/relative_address.py
+++ b/src/bespokeasm/assembler/model/operand/types/relative_address.py
@@ -53,10 +53,17 @@ class RelativeAddressByteCodePart(ExpressionByteCodePartInMemoryZone):
         active_named_scopes: ActiveNamedScopeList,
         instruction_address: int,
         instruction_size: int,
+        bytecode_address: int | None = None,
     ) -> int:
         if instruction_address is None:
             raise ValueError('RelativeAddressByteCodePart.get_value had no instruction_address passed')
-        expression_value = super().get_value(label_scope, active_named_scopes, instruction_address, instruction_size)
+        expression_value = super().get_value(
+            label_scope,
+            active_named_scopes,
+            instruction_address,
+            instruction_size,
+            bytecode_address,
+        )
         relative_value = expression_value - instruction_address
         if self._offset_from_instruction_end:
             # minus one to account for the current address being 1 byte of instruction size

--- a/src/bespokeasm/docsgen/documentation_model.py
+++ b/src/bespokeasm/docsgen/documentation_model.py
@@ -862,7 +862,10 @@ class DocumentationModel:
                     notes.append('Uses only the least significant bits of the address value.')
 
                 if argument_config.get('match_address_msb'):
-                    notes.append('High address bits are taken from the current instruction address.')
+                    if argument_config.get('match_on_argument_bytcode'):
+                        notes.append('High address bits are taken from the operand fetch page.')
+                    else:
+                        notes.append('High address bits are taken from the current instruction address.')
 
         if operand_type == 'relative_address':
             if operand_config.get('use_curly_braces'):

--- a/test/config_files/test_valid_address_enforcement.yaml
+++ b/test/config_files/test_valid_address_enforcement.yaml
@@ -167,6 +167,23 @@ instructions:
                 word_align: true
                 slice_lsb: true
                 match_address_msb: true
+  jmp_local_operand_page:
+    bytecode:
+      value: 0xE3
+      size: 8
+    operands:
+      count: 1
+      specific_operands:
+        local_addr:
+          list:
+            local_addr:
+              type: address
+              argument:
+                size: 8
+                word_align: true
+                slice_lsb: true
+                match_address_msb: true
+                match_on_argument_bytcode: true
   jmpa:
     bytecode:
       value: 0xE1

--- a/test/test_docsgen/test_documentation_model.py
+++ b/test/test_docsgen/test_documentation_model.py
@@ -199,6 +199,22 @@ class TestDocumentationModel(unittest.TestCase):
         self.assertEqual(len(mov2_doc['versions']), 1)
         self.assertEqual(len(mov2_doc['versions'][0]['signatures'][0]['operands']), 2)
 
+    def test_address_operand_auto_details_describe_operand_fetch_page(self):
+        notes = DocumentationModel._derive_operand_auto_details(
+            'address',
+            {
+                'argument': {
+                    'slice_lsb': True,
+                    'match_address_msb': True,
+                    'match_on_argument_bytcode': True,
+                }
+            },
+            has_manual_description=False,
+        )
+
+        self.assertIn('Uses only the least significant bits of the address value.', notes)
+        self.assertIn('High address bits are taken from the operand fetch page.', notes)
+
     def test_macro_category_defaults_when_none(self):
         """A None category is treated as Uncategorized instead of breaking sorting."""
         self.mock_isa_model._config = {

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -344,10 +344,11 @@ class TestAssemblerEngine(unittest.TestCase):
             with self.assertRaises(SystemExit) as ctx:
                 assembler.assemble_bytecode()
 
-        self.assertIn(
-            'Operand address value 0x29fa does not have the same MSBs as the instruction address 0x2a10',
-            str(ctx.exception),
-        )
+        error_text = str(ctx.exception).lower()
+        self.assertIn('instruction address 0x2a10', error_text)
+        self.assertIn('operand byte address 0x2a11', error_text)
+        self.assertIn('page comparison address 0x2a10', error_text)
+        self.assertIn('target address 0x29fa', error_text)
         self.assertIn('line 2', str(ctx.exception))
 
     def test_generate_bytes_from_line_objects_4bit_words_with_fill(self):

--- a/test/test_instruction_parsing.py
+++ b/test/test_instruction_parsing.py
@@ -1,5 +1,6 @@
 import importlib.resources as pkg_resources
 import unittest
+from pathlib import Path
 
 from bespokeasm.assembler.bytecode.word import Word
 from bespokeasm.assembler.diagnostic_reporter import DiagnosticReporter
@@ -1140,6 +1141,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             False,
             False,
+            False,
             isa_model.word_size,
             isa_model.word_segment_size,
         )
@@ -1157,6 +1159,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_mngr.global_zone,
             True,
             True,
+            False,
             isa_model.word_size,
             isa_model.word_segment_size,
         )
@@ -1177,6 +1180,7 @@ class TestInstructionParsing(unittest.TestCase):
             memzone_32bit_mngr.global_zone,
             True,
             True,
+            False,
             isa_model.word_size,
             isa_model.word_segment_size,
         )
@@ -1198,9 +1202,79 @@ class TestInstructionParsing(unittest.TestCase):
                 memzone_mngr.global_zone,
                 True,
                 False,
+                False,
                 isa_model.word_size,
                 isa_model.word_segment_size,
             )
+
+        # boundary behavior defaults to comparing against the instruction address page
+        bc4 = AddressByteCodePart(
+            '$27AA',
+            8,
+            True,
+            isa_model.multi_word_endianness,
+            isa_model.intra_word_endianness,
+            lineid,
+            memzone_mngr.global_zone,
+            True,
+            True,
+            False,
+            isa_model.word_size,
+            isa_model.word_segment_size,
+        )
+        with self.assertRaisesRegex(
+            ValueError,
+            'instruction address 0x26ff',
+        ):
+            bc4.get_value(TestInstructionParsing.label_values, self.active_named_scopes, 0x26FF, 2)
+
+        # operand-page matching uses the emitted operand byte address, which crosses to 0x2700 at 0x26FF
+        bc5 = AddressByteCodePart(
+            '$27AA',
+            8,
+            True,
+            isa_model.multi_word_endianness,
+            isa_model.intra_word_endianness,
+            lineid,
+            memzone_mngr.global_zone,
+            True,
+            True,
+            True,
+            isa_model.word_size,
+            isa_model.word_segment_size,
+        )
+        value5 = bc5.get_value(
+            TestInstructionParsing.label_values,
+            self.active_named_scopes,
+            0x26FF,
+            2,
+            0x2700,
+        )
+        self.assertEqual(value5, 0xAA, 'operand-page matching should accept next-page target at xxFF')
+        with self.assertRaises(ValueError) as ctx:
+            AddressByteCodePart(
+                '$26AA',
+                8,
+                True,
+                isa_model.multi_word_endianness,
+                isa_model.intra_word_endianness,
+                lineid,
+                memzone_mngr.global_zone,
+                True,
+                True,
+                True,
+                isa_model.word_size,
+                isa_model.word_segment_size,
+            ).get_value(
+                TestInstructionParsing.label_values,
+                self.active_named_scopes,
+                0x26FF,
+                2,
+                0x2700,
+            )
+        self.assertIn('instruction address 0x26ff', str(ctx.exception))
+        self.assertIn('operand byte address 0x2700', str(ctx.exception))
+        self.assertIn('target address 0x26aa', str(ctx.exception).lower())
 
         # Test byte code generation for sliced addresses
         t1 = InstructionLine.factory(
@@ -1226,6 +1300,25 @@ class TestInstructionParsing(unittest.TestCase):
         t1.set_start_address(0x3350)
         with self.assertRaises(ValueError, msg="address MSBs don't match"):
             t1.generate_words()
+
+        # the operand-page variant should validate against the operand byte address at xxFF
+        t1_operand_page = InstructionLine.factory(
+            lineid, 'jmp_local_operand_page $27AA', 'comment',
+            isa_model, memzone_mngr.global_zone, memzone_mngr,
+        )
+        t1_operand_page.set_start_address(0x26FF)
+        t1_operand_page.label_scope = TestInstructionParsing.label_values
+        t1_operand_page.active_named_scopes = self.active_named_scopes
+        self.assertIsInstance(t1_operand_page, InstructionLine)
+        t1_operand_page.generate_words()
+        self.assertEqual(
+            list(t1_operand_page.get_words()),
+            [
+                Word(0xE3, 8, 8, isa_model.intra_word_endianness),
+                Word(0xAA, 8, 8, isa_model.intra_word_endianness),
+            ],
+            'operand-page variant should emit the low byte for the next page target',
+        )
 
         # Test bye code generation for unsliced addresses
         t2 = InstructionLine.factory(
@@ -1281,6 +1374,78 @@ class TestInstructionParsing(unittest.TestCase):
         self.assertEqual(t4.word_count, 3, 'has 3 words')
         with self.assertRaises(SystemExit, msg='address not in target memory zone'):
             t4.generate_words()
+
+    def test_minimal_fast_ops_validate_against_operand_fetch_page(self):
+        minimal_fp = (
+            Path(__file__).resolve().parents[1]
+            / 'examples'
+            / 'slu4-minimal-64x4'
+            / 'slu4-minimal-64x4.yaml'
+        )
+        isa_model = AssemblerModel(str(minimal_fp), 0, self.diagnostic_reporter)
+        memzone_mngr = MemoryZoneManager(
+            isa_model.address_size,
+            isa_model.default_origin,
+            isa_model.predefined_memory_zones,
+        )
+        lineid = LineIdentifier(43, 'test_minimal_fast_ops_validate_against_operand_fetch_page')
+        opcode_map = {
+            'feq': 0x54,
+            'fpa': 0x5B,
+        }
+        cases = [
+            (0x26FE, 0x26AA, True),
+            (0x26FE, 0x27AA, False),
+            (0x26FF, 0x26AA, False),
+            (0x26FF, 0x27AA, True),
+        ]
+
+        for mnemonic, opcode in opcode_map.items():
+            for instruction_address, target_address, should_pass in cases:
+                with self.subTest(
+                    mnemonic=mnemonic,
+                    instruction_address=hex(instruction_address),
+                    target_address=hex(target_address),
+                ):
+                    line = InstructionLine.factory(
+                        lineid,
+                        f'{mnemonic} ${target_address:04X}',
+                        'comment',
+                        isa_model,
+                        memzone_mngr.global_zone,
+                        memzone_mngr,
+                    )
+                    line.set_start_address(instruction_address)
+                    line.label_scope = isa_model.global_label_scope
+                    line.active_named_scopes = self.active_named_scopes
+                    self.assertIsInstance(line, InstructionLine)
+                    self.assertEqual(line.word_count, 2, 'fast ops should emit opcode plus one-byte operand')
+
+                    if should_pass:
+                        line.generate_words()
+                        self.assertEqual(
+                            list(line.get_words()),
+                            [
+                                Word(opcode, 8, 8, isa_model.intra_word_endianness),
+                                Word(target_address & 0xFF, 8, 8, isa_model.intra_word_endianness),
+                            ],
+                            'fast op should emit opcode plus target low byte',
+                        )
+                    else:
+                        with self.assertRaises(ValueError) as ctx:
+                            line.generate_words()
+                        self.assertIn(
+                            f'instruction address 0x{instruction_address:x}',
+                            str(ctx.exception).lower(),
+                        )
+                        self.assertIn(
+                            f'operand byte address 0x{instruction_address + 1:x}',
+                            str(ctx.exception).lower(),
+                        )
+                        self.assertIn(
+                            f'target address 0x{target_address:x}',
+                            str(ctx.exception).lower(),
+                        )
 
     def test_instruction_parsing_16bit_word(self):
         fp = pkg_resources.files(config_files).joinpath('test_16bit_data_words.yaml')


### PR DESCRIPTION
Improved slicing of address operands in "fast jump" style operands where the address is determined with the operand value representing the low bits of the address and the app bits coming from the location of the instruction address. This allows fast jumps that are within the same page as the instruction. This change allows you to configure the selection of the upper bits to be either the instruction byte code address or the address of the operand value's byte code. This option is useful when the instruction's microcode calculates the finalize jump address after the operand value is loaded and thus the program counter is pointing at the operand, which may be in a different page than the instruction byte code address. 

Updated the configuration of the Minimal 64x4 instruction set to use the operand address for calculating the MSB used in fast jump target addresses.

Also prepared for the v0.7.2 release.