### PR TITLE
fix(engine): report diagnostic for empty source instead of IndexError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changes that are planned but not implemented yet:
 * Added semantic label-usage highlighting in Vim: references to labels defined in the buffer are highlighted distinctly from arbitrary identifiers.
 * Added hover-equivalent documentation in Vim: pressing `K` over a mnemonic, register, directive, expression function, or predefined symbol opens its documentation in a preview window. An optional auto-popup variant (vim 8.2+ / Neovim) is available via `g:bespokeasm_<ft>_auto_hover`.
 * Improved unit test coverage
+* Fixed an `IndexError` crash when compiling a source file with no compilable lines; a clear diagnostic error is now reported instead.
 
 ## [0.7.3]
 * Added configurable mnemonic decorators (`+`, `-`, `++`, `--`, `!`, `@`) so instruction variants can use prefixed or suffixed decorated mnemonics such as `m+`, `m-`, and `++inc`.

--- a/src/bespokeasm/assembler/engine.py
+++ b/src/bespokeasm/assembler/engine.py
@@ -195,12 +195,12 @@ class Assembler:
         compilable_line_obs.extend(predefined_line_obs)
 
         # Sort lines according to their assigned address. This allows for .org directives
-        compilable_line_obs.sort(key=lambda x: x.address)
-        if len(compilable_line_obs) == 0:
+        if not compilable_line_obs:
             diagnostic_reporter.error(
                 None,
                 'source file contains no compilable lines',
             )
+        compilable_line_obs.sort(key=lambda x: x.address)
         max_generated_address = compilable_line_obs[-1].address
         line_dict = {
             lobj.address: lobj

--- a/src/bespokeasm/assembler/engine.py
+++ b/src/bespokeasm/assembler/engine.py
@@ -196,6 +196,11 @@ class Assembler:
 
         # Sort lines according to their assigned address. This allows for .org directives
         compilable_line_obs.sort(key=lambda x: x.address)
+        if len(compilable_line_obs) == 0:
+            diagnostic_reporter.error(
+                None,
+                'source file contains no compilable lines',
+            )
         max_generated_address = compilable_line_obs[-1].address
         line_dict = {
             lobj.address: lobj

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -314,6 +314,34 @@ class TestAssemblerEngine(unittest.TestCase):
                 assembler.assemble_bytecode()
             self.assertIn('overlaps', str(ctx.exception))
 
+    def test_empty_source_reports_diagnostic(self):
+        """An empty source file reports a friendly error instead of IndexError."""
+        fp = pkg_resources.files(config_files).joinpath('test_instruction_operands.yaml')
+        config_path = str(fp)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            asm_path = os.path.join(temp_dir, 'empty.asm')
+            with open(asm_path, 'w') as handle:
+                handle.write('')
+
+            assembler = Assembler(
+                source_file=asm_path,
+                config_file=config_path,
+                generate_binary=False,
+                output_file=None,
+                binary_start=None,
+                binary_end=None,
+                binary_fill_value=0,
+                enable_pretty_print=False,
+                pretty_print_format=None,
+                pretty_print_output=None,
+                is_verbose=0,
+                include_paths=[temp_dir],
+                predefined=[],
+            )
+            with self.assertRaises(SystemExit) as ctx:
+                assembler.assemble_bytecode()
+            self.assertIn('no compilable lines', str(ctx.exception))
+
     def test_msb_mismatch_in_second_pass_reports_line_diagnostic(self):
         fp = pkg_resources.files(config_files).joinpath('test_valid_address_enforcement.yaml')
         config_path = str(fp)


### PR DESCRIPTION
Compiling an empty source file crashed with `IndexError: list index out of range` at `engine.py` because `compilable_line_obs[-1]` was accessed on an empty list. The engine now reports a clear `source file contains no compilable lines` diagnostic in that case. Closes #53.